### PR TITLE
Dir glob feature when using **/* pattern

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -109,11 +109,14 @@ module FakeFS
       matches = case pattern
       when '**'
         case parts
-        when ['*'], []
+        when ['*']
           parts = [] # end recursion
           directories_under(dir).map do |d|
-            d.values.select{|f| f.is_a? FakeFile }
+            d.values.select{|f| f.is_a?(FakeFile) || f.is_a?(FakeDir) }
           end.flatten.uniq
+        when []
+          parts = [] # end recursion
+          dir.values.flatten.uniq
         else
           directories_under(dir)
         end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -458,6 +458,13 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal ['/path/foo', '/path/foobar'], Dir['/p*h/foo*']
     assert_equal ['/path/foo', '/path/foobar'], Dir['/p??h/foo*']
 
+    assert_equal ['/path/bar', '/path/bar/baz', '/path/bar2', '/path/bar2/baz', '/path/foo', '/path/foobar'], Dir['/path/**/*']
+    assert_equal ['/path', '/path/bar', '/path/bar/baz', '/path/bar2', '/path/bar2/baz', '/path/foo', '/path/foobar'], Dir['/**/*']
+
+    assert_equal ['/path/bar', '/path/bar/baz', '/path/bar2', '/path/bar2/baz', '/path/foo', '/path/foobar'], Dir['/path/**/*']
+    
+    assert_equal ['/path/bar/baz'], Dir['/path/bar/**/*']
+
     FileUtils.cp_r '/path', '/otherpath'
 
     assert_equal %w( /otherpath/foo /otherpath/foobar /path/foo /path/foobar ), Dir['/*/foo*']
@@ -478,11 +485,11 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal ['/one/two/three'], Dir['/one/**/three']
   end
 
-  def test_dir_recursive_glob_ending_in_wildcards_only_returns_files
+  def test_dir_recursive_glob_ending_in_wildcards_returns_both_files_and_dirs
     File.open('/one/two/three/four.rb', 'w')
     File.open('/one/five.rb', 'w')
-    assert_equal ['/one/five.rb', '/one/two/three/four.rb'], Dir['/one/**/*']
-    assert_equal ['/one/five.rb', '/one/two/three/four.rb'], Dir['/one/**']
+    assert_equal ['/one/five.rb', '/one/two', '/one/two/three', '/one/two/three/four.rb'], Dir['/one/**/*']
+    assert_equal ['/one/five.rb', '/one/two'], Dir['/one/**']
   end
 
   def test_should_report_pos_as_0_when_opening


### PR DESCRIPTION
Hello,

This fix applies to the issue where doing Dir['*_/_'] would list only files, excluding directories.
This change will make fakefs behaves like the core ruby lib, return files and folders as well.
Tests were updated following carefully tests with the ruby core lib.

I've created an issue a few days ago, please ignore that, since the branch I point there has another changes regarding the Gemspec. Also there was another issue created a long time ago for the same problem, you may close that as well.

Thanks.
