### PR TITLE
FileUtils.mv raises exception with a proper message

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -101,7 +101,7 @@ module FakeFS
           FileSystem.add(dest_path, target.entry.clone)
           FileSystem.delete(path)
         else
-          raise Errno::ENOENT, src
+          raise Errno::ENOENT, path
         end
       end
     end


### PR DESCRIPTION
[As zenspider pointed out](https://github.com/wijet/fakefs/commit/69864638623e20b58c4d852efdfcc3cd8fae021e) Errno::ENOENT exception should be raised with a particular "path" not with "src", which may be an array now. Next time I will pay more attention when merging :)
