### PR TITLE
FileUtils.mv raises exception with a proper message

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -101,7 +101,7 @@ module FakeFS
           FileSystem.add(dest_path, target.entry.clone)
           FileSystem.delete(path)
         else
-          raise Errno::ENOENT, src
+          raise Errno::ENOENT, path
         end
       end
     end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -793,6 +793,10 @@ class FakeFSTest < Test::Unit::TestCase
     assert_raise(Errno::ENOENT) do
       FileUtils.mv 'blafgag', 'foo'
     end
+    exception = assert_raise(Errno::ENOENT) do
+      FileUtils.mv ['foo', 'bar'], 'destdir'
+    end
+    assert_equal "No such file or directory - foo", exception.message
   end
 
   def test_mv_actually_works


### PR DESCRIPTION
[As zenspider pointed out](https://github.com/wijet/fakefs/commit/69864638623e20b58c4d852efdfcc3cd8fae021e) Errno::ENOENT exception should be raised with a particular "path" not with "src", which may be an array now. I've also added a test for this case and put it into one commit. Next time I will pay more attention when merging :)
