### PR TITLE
Fix for finding files by patterns that include {}

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -121,7 +121,7 @@ module FakeFS
           directories_under(dir)
         end
       else
-        regexp_pattern = /\A#{pattern.gsub('?','.').gsub('*', '.*').gsub(/\{(.*?)\}/) { "(#{$1.split(',').join('|')})" }}\Z/
+        regexp_pattern = /\A#{pattern.gsub('?','.').gsub('*', '.*').gsub(/\{(.*?)\}/) { "(#{$1.gsub(',', '|')})" }}\Z/
         dir.reject {|k,v| regexp_pattern !~ k }.values
       end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -566,6 +566,8 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal %w( /otherpath/foo /otherpath/foobar /path/foo /path/foobar ), Dir['/*/foo*']
 
     assert_equal ['/path/bar', '/path/foo'], Dir['/path/{foo,bar}']
+
+    assert_equal ['/path/bar', '/path/bar2'], Dir['/path/bar{2,}']
   end
 
   def test_dir_glob_handles_root


### PR DESCRIPTION
This should fix finding files by patterns like /foo/{bar,baz}
