### PR TITLE
Compatability with Rails3 page caching

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -6,6 +6,7 @@ module FakeFS
       FileSystem.add(path, FakeDir.new)
     end
     alias_method :mkpath, :mkdir_p
+    alias_method :makedirs, :mkdir_p
 
     def mkdir(path)
       parent = path.split('/')

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -55,6 +55,16 @@ class FakeFSTest < Test::Unit::TestCase
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
   end
 
+  def test_can_create_directories_with_mkpath
+    FileUtils.makedirs("/path/to/dir")
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_can_create_directories_with_mkpath_and_options
+    FileUtils.makedirs("/path/to/dir", :mode => 0755)
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
   def test_can_delete_directories
     FileUtils.mkdir_p("/path/to/dir")
     FileUtils.rmdir("/path/to/dir")


### PR DESCRIPTION
It doesn't look like this has changed in Rails between 2 & 3 but some of our tests are failing under Rails3 because makedirs isn't available in the fakefs/fileutils.  Added alias for makedirs.  Compatible with standard Rubies 1.8.7,1.9.2 as well.

Rails ref - https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/caching/pages.rb
1.9.2 ref - http://www.ruby-doc.org/stdlib/libdoc/fileutils/rdoc/index.html
