### PR TITLE
Improved error handling for Dir.delete and Dir.entries

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -65,12 +65,13 @@ module FakeFS
     end
 
     def self.delete(string)
-      raise SystemCallError, "No such file or directory - #{string}" unless FileSystem.find(string).values.empty?
+      raise Errno::ENOENT, "No such file or directory - #{string}" unless FileSystem.find(string)
+      raise Errno::ENOTEMPTY, "Directory not empty - #{string}" unless FileSystem.find(string).values.empty?
       FileSystem.delete(string)
     end
 
     def self.entries(dirname)
-      raise SystemCallError, dirname unless FileSystem.find(dirname)
+      raise Errno::ENOENT, "No such file or directory - #{dirname}" unless FileSystem.find(dirname)
       Dir.new(dirname).map { |file| File.basename(file) }
     end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1211,8 +1211,14 @@ class FakeFSTest < Test::Unit::TestCase
       FileUtils.touch("/this/path/should/be/here/#{f}")
     end
 
-    assert_raises(SystemCallError) do
+    assert_raises(Errno::ENOTEMPTY) do
       Dir.delete('/this/path/should/be/here')
+    end
+  end
+
+  def test_directory_class_delete_does_not_work_if_dir_path_cannot_be_found
+    assert_raises(Errno::ENOENT) do
+      Dir.delete('/this/path/should/not/be/here')
     end
   end
 
@@ -1242,6 +1248,12 @@ class FakeFSTest < Test::Unit::TestCase
     yielded = Dir.entries('/this/path/should/be/here/')
     assert yielded.size == test.size
     test.each { |t| assert yielded.include?(t) }
+  end
+
+  def test_directory_entries_does_not_work_if_dir_path_cannot_be_found
+    assert_raises(Errno::ENOENT) do
+      Dir.delete('/this/path/should/not/be/here')
+    end
   end
 
   def test_directory_foreach


### PR DESCRIPTION
This better matches the behavior of Ruby 1.8 and 1.9

Specifically, I needed this more accurate error behavior when I tried using FakeFS with the latest version of [CarrierWave](https://github.com/jnicklas/carrierwave).  CarrierWave relies on checking for `Errno::ENOENT` and `Errno::ENOTEMPTY`.
