### PR TITLE
Added basic File#to_path support

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -358,7 +358,7 @@ module FakeFS
       end
 
       def to_path
-        raise NotImplementedError
+        @path
       end
     end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1651,5 +1651,11 @@ class FakeFSTest < Test::Unit::TestCase
         assert_equal false, f.autoclose?
       end
     end
+
+    def test_to_path
+      File.new("foo", 'w') do |f|
+        assert_equal "foo", f.to_path
+      end
+    end
   end
 end


### PR DESCRIPTION
A lot of libraries call `File#to_path`, and when using FakeFS around them, the existing `NotImplementedError` caused me to monkey-patch `File#to_path` on too many projects.
