### PR TITLE
Fix creation of absolute path subdirs with Dir.mkdir, closes #96

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -96,15 +96,7 @@ module FakeFS
     end
 
     def self.mkdir(string, integer = 0)
-      parent = string.split('/')
-      parent.pop
-
-      joined_parent_path = parent.join
-
-      _check_for_valid_file(joined_parent_path) unless joined_parent_path == ""
-      raise Errno::EEXIST, "File exists - #{string}" if File.exists?(string)
-
-      FileUtils.mkdir_p(string)
+      FileUtils.mkdir(string)
     end
 
     def self.open(string, &block)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1413,6 +1413,18 @@ class FakeFSTest < Test::Unit::TestCase
     assert File.exists?('/path')
   end
 
+  def test_can_create_subdirectories_with_dir_mkdir
+    Dir.mkdir 'foo'
+    Dir.mkdir 'foo/bar'
+    assert Dir.exists?('foo/bar')
+  end
+
+  def test_can_create_absolute_subdirectories_with_dir_mkdir
+    Dir.mkdir '/foo'
+    Dir.mkdir '/foo/bar'
+    assert Dir.exists?('/foo/bar')
+  end
+
   def test_directory_mkdir_relative
     FileUtils.mkdir_p('/new/root')
     FileSystem.chdir('/new/root')


### PR DESCRIPTION
Reuse `FileUtils.mkdir` to implement `Dir.mkdir`, fixes #96
