### PR TITLE
Dir glob will accept multiple arguments.

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -52,8 +52,8 @@ module FakeFS
       @contents[integer]
     end
 
-    def self.[](pattern)
-      glob(pattern)
+    def self.[](*pattern)
+      glob pattern
     end
 
     def self.chdir(dir, &blk)
@@ -79,8 +79,14 @@ module FakeFS
     end
 
     def self.glob(pattern, &block)
-      files = [FileSystem.find(pattern) || []].flatten.map(&:to_s).sort
-      block_given? ? files.each { |file| block.call(file) } : files
+      matches_for_pattern = lambda { |matcher| [FileSystem.find(matcher) || []].flatten.map{|e| e.to_s}.sort  }
+
+      if pattern.is_a? Array
+        files = pattern.collect { |matcher| matches_for_pattern.call matcher }.flatten
+      else
+        files = matches_for_pattern.call pattern
+      end
+      return block_given? ? files.each { |file| block.call(file) } : files
     end
 
     def self.mkdir(string, integer = 0)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -561,6 +561,9 @@ class FakeFSTest < Test::Unit::TestCase
 
     assert_equal ['/path/bar/baz'], Dir['/path/bar/**/*']
 
+    assert_equal ['/path/bar/baz', '/path/bar2/baz'], Dir['/path/bar/**/*', '/path/bar2/**/*']
+    assert_equal ['/path/bar/baz', '/path/bar2/baz', '/path/bar/baz'], Dir['/path/ba*/**/*', '/path/bar/**/*']
+
     FileUtils.cp_r '/path', '/otherpath'
 
     assert_equal %w( /otherpath/foo /otherpath/foobar /path/foo /path/foobar ), Dir['/*/foo*']


### PR DESCRIPTION
Dir[] glob method should be able to accept multiple arguments. This relates to issue #100 ( https://github.com/defunkt/fakefs/issues/100 ) .

Example:
Dir['/path/bar//_', '/path/bar2//_']
