### PR TITLE
Dir.mkdir would fail if path starts with dot.

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -92,7 +92,7 @@ module FakeFS
     def self.mkdir(string, integer = 0)
       parent = string.split('/')
       parent.pop
-      raise Errno::ENOENT, "No such file or directory - #{string}" unless parent.join == "" || FileSystem.find(parent.join('/'))
+      raise Errno::ENOENT, "No such file or directory - #{string}" unless parent.join == "" || parent.join == "." || FileSystem.find(parent.join('/'))
       raise Errno::EEXIST, "File exists - #{string}" if File.exists?(string)
       FileUtils.mkdir_p(string)
     end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1257,6 +1257,11 @@ class FakeFSTest < Test::Unit::TestCase
     assert File.exists?('/path')
   end
 
+  def test_can_create_directories_starting_with_dot
+    Dir.mkdir './path'
+    assert File.exists? './path'
+  end
+
   def test_directory_mkdir_relative
     FileUtils.mkdir_p('/new/root')
     FileSystem.chdir('/new/root')


### PR DESCRIPTION
Fixed issue where Dir.mkdir would fail if path starts with dot.

Example:
Dir.mkdir './path'
