### PR TITLE
Dir.glob should be able receive a flag for finding dirs starting with a dot

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -78,8 +78,8 @@ module FakeFS
       Dir.open(dirname) { |file| yield file }
     end
 
-    def self.glob(pattern, &block)
-      matches_for_pattern = lambda { |matcher| [FileSystem.find(matcher) || []].flatten.map{|e| e.to_s}.sort  }
+    def self.glob(pattern, flags = 0, &block)
+      matches_for_pattern = lambda { |matcher| [FileSystem.find(matcher, flags) || []].flatten.map{|e| e.to_s}.sort  }
 
       if pattern.is_a? Array
         files = pattern.collect { |matcher| matches_for_pattern.call matcher }.flatten

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -19,11 +19,11 @@ module FakeFS
       fs.values
     end
 
-    def find(path)
+    def find(path, flags = 0)
       parts = path_parts(normalize_path(path))
       return fs if parts.empty? # '/'
 
-      entries = find_recurser(fs, parts).flatten
+      entries = find_recurser(fs, parts, flags).flatten
 
       case entries.length
       when 0 then nil
@@ -102,7 +102,7 @@ module FakeFS
 
     private
 
-    def find_recurser(dir, parts)
+    def find_recurser(dir, parts, flags)
       return [] unless dir.respond_to? :[]
 
       pattern , *parts = parts
@@ -111,14 +111,14 @@ module FakeFS
         case parts
         when ['*']
           parts = [] # end recursion
-          directories_under(dir).map do |d|
+          directories_under(dir, flags).map do |d|
             d.values.select{|f| f.is_a?(FakeFile) || is_a_directory_and_matches_flags?(f, 0)}
           end.flatten.uniq
         when []
           parts = [] # end recursion
           dir.values.flatten.uniq
         else
-          directories_under(dir)
+          directories_under(dir, flags)
         end
       else
         dir.reject {|k,v| /\A#{pattern.gsub('?','.').gsub('*', '.*')}\Z/ !~ k }.values
@@ -127,17 +127,18 @@ module FakeFS
       if parts.empty? # we're done recursing
         matches
       else
-        matches.map{|entry| find_recurser(entry, parts) }
+        matches.map{|entry| find_recurser(entry, parts, flags) }
       end
     end
 
-    def directories_under(dir)
-      children = dir.values.select{|f| is_a_directory_and_matches_flags?(f, 0)}
-      ([dir] + children + children.map{|c| directories_under(c)}).flatten.uniq
+    def directories_under(dir, flags)
+      children = dir.values.select{|f| is_a_directory_and_matches_flags?(f, flags)}
+      ([dir] + children + children.map{|c| directories_under(c, flags)}).flatten.uniq
     end
 
     def is_a_directory_and_matches_flags?(entry, flags)
-      entry.is_a?(FakeDir) && entry.name !~ /^\./
+      return entry.is_a?(FakeDir) if flags == File::FNM_DOTMATCH
+      return entry.is_a?(FakeDir) && entry.name !~ /^\./ if flags != File::FNM_DOTMATCH
     end
   end
 end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -606,6 +606,11 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal [], Dir['/one/**/*']
   end
 
+  def test_dir_glob_can_be_overridden_to_match_dot_dirs
+    File.open('/one/.dotdir/three.rb', 'w')
+    assert_equal ['/one/.dotdir/three.rb'], Dir.glob(['/one/**/*'], File::FNM_DOTMATCH)
+  end
+
   def test_should_report_pos_as_0_when_opening
     File.open("/foo", "w") do |f|
       f << "foobar"


### PR DESCRIPTION
Dir[] glob receives a flag for finding dirs starting with a dot.

Example:
If '/one/.dotdir/three.rb' exists

Dir.glob(['/one/*_/_'], File::FNM_DOTMATCH).should == ['/one/.dotdir/three.rb']
