### PR TITLE
Added support for atime

### DIFF
--- a/lib/fakefs/fake/dir.rb
+++ b/lib/fakefs/fake/dir.rb
@@ -1,13 +1,14 @@
 module FakeFS
   class FakeDir < Hash
     attr_accessor :name, :parent
-    attr_reader :ctime, :mtime
+    attr_reader :ctime, :mtime, :atime
 
     def initialize(name = nil, parent = nil)
       @name   = name
       @parent = parent
       @ctime  = Time.now
       @mtime  = @ctime
+      @atime  = @ctime
     end
 
     def entry

--- a/lib/fakefs/fake/file.rb
+++ b/lib/fakefs/fake/file.rb
@@ -1,6 +1,6 @@
 module FakeFS
   class FakeFile
-    attr_accessor :name, :parent, :content, :mtime
+    attr_accessor :name, :parent, :content, :mtime, :atime
     attr_reader :ctime
 
     class Inode
@@ -34,6 +34,7 @@ module FakeFS
       @inode  = Inode.new(self)
       @ctime  = Time.now
       @mtime  = @ctime
+      @atime  = @ctime
     end
 
     attr_accessor :inode


### PR DESCRIPTION
I'm writing a script that cleans a dir with cache files in a smart way; it starts removing the least accessed file, until we've cleared enough GB's.

I started to test this with fake fs, but that's when I discovered that FakeFS diddn't support atime!

Therefore, I forked and implemented atime.
