### PR TITLE
Fix Dir.glob: return relative paths when necessary

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -91,7 +91,7 @@ module FakeFS
     end
 
     def self.glob(pattern, &block)
-      matches_for_pattern = lambda { |matcher| [FileSystem.find(matcher) || []].flatten.map{|e| e.to_s}.sort  }
+      matches_for_pattern = lambda { |matcher| [FileSystem.find(matcher) || []].flatten.map{|e| Dir.pwd.match(%r[\A/?\z]) ? e.to_s : e.to_s.match(%r[\A#{Dir.pwd}/?]).post_match}.sort  }
 
       if pattern.is_a? Array
         files = pattern.collect { |matcher| matches_for_pattern.call matcher }.flatten

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -752,6 +752,10 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal ['/path/bar', '/path/foo'], Dir['/path/{foo,bar}']
 
     assert_equal ['/path/bar', '/path/bar2'], Dir['/path/bar{2,}']
+
+    Dir.chdir '/path' do
+      assert_equal ['foo'], Dir['foo']
+    end
   end
 
   def test_dir_glob_handles_root


### PR DESCRIPTION
Closes #98

FileUtils.touch '/path/foo'
Dir.chdir '/path'
Dir.pwd #= '/path'
Dir['foo'] #= ['foo'] != ['/path/foo']

Includes updated test
