### PR TITLE
Add reverse to FakeFS method, to disable FakeFS temporarily

### DIFF
--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -4,42 +4,73 @@ RealFileUtils       = FileUtils
 RealDir             = Dir
 
 module FakeFS
-  def self.activate!
-    Object.class_eval do
-      remove_const(:Dir)
-      remove_const(:File)
-      remove_const(:FileTest)
-      remove_const(:FileUtils)
-
-      const_set(:Dir,       FakeFS::Dir)
-      const_set(:File,      FakeFS::File)
-      const_set(:FileUtils, FakeFS::FileUtils)
-      const_set(:FileTest,  FakeFS::FileTest)
+  @activated = false
+  class << self
+    def activated?
+      @activated
     end
-    true
-  end
 
-  def self.deactivate!
-    Object.class_eval do
-      remove_const(:Dir)
-      remove_const(:File)
-      remove_const(:FileTest)
-      remove_const(:FileUtils)
+    def activate!
+      @activated = true
+      Object.class_eval do
+        remove_const(:Dir)
+        remove_const(:File)
+        remove_const(:FileTest)
+        remove_const(:FileUtils)
 
-      const_set(:Dir,       RealDir)
-      const_set(:File,      RealFile)
-      const_set(:FileTest,  RealFileTest)
-      const_set(:FileUtils, RealFileUtils)
+        const_set(:Dir,       FakeFS::Dir)
+        const_set(:File,      FakeFS::File)
+        const_set(:FileUtils, FakeFS::FileUtils)
+        const_set(:FileTest,  FakeFS::FileTest)
+      end
+      true
     end
-    true
+
+    def deactivate!
+      @activated = false
+      Object.class_eval do
+        remove_const(:Dir)
+        remove_const(:File)
+        remove_const(:FileTest)
+        remove_const(:FileUtils)
+
+        const_set(:Dir,       RealDir)
+        const_set(:File,      RealFile)
+        const_set(:FileTest,  RealFileTest)
+        const_set(:FileUtils, RealFileUtils)
+      end
+      true
+    end
+
+    def with
+      if activated?
+        yield
+      else
+        begin
+          activate!
+          yield
+        ensure
+          deactivate!
+        end
+      end
+    end
+
+    def without
+      if !activated?
+        yield
+      else
+        begin
+          deactivate!
+          yield
+        ensure
+          activate!
+        end
+      end
+    end
   end
 end
 
-def FakeFS
-  return ::FakeFS unless block_given?
-  ::FakeFS.activate!
-  yield
-ensure
-::FakeFS.deactivate!
+def FakeFS(&block)
+  return ::FakeFS unless block
+  ::FakeFS.with(&block)
 end
-


### PR DESCRIPTION
This is really useful when a Gem has some data files in it, and the code being tested needs to use those files. Also added a `FakeFS.disabled?` method to support this. Includes tests.
