### PR TITLE
Favor composition over inheritance for FakeDir

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -12,7 +12,7 @@ module FakeFS
       @path = string
       @open = true
       @pointer = 0
-      @contents = [ '.', '..', ] + FileSystem.find(@path).values
+      @contents = [ '.', '..', ] + FileSystem.find(@path).entries
     end
 
     def close
@@ -75,7 +75,7 @@ module FakeFS
 
     def self.delete(string)
       _check_for_valid_file(string)
-      raise Errno::ENOTEMPTY, "Directory not empty - #{string}" unless FileSystem.find(string).values.empty?
+      raise Errno::ENOTEMPTY, "Directory not empty - #{string}" unless FileSystem.find(string).empty?
 
       FileSystem.delete(string)
     end

--- a/lib/fakefs/fake/dir.rb
+++ b/lib/fakefs/fake/dir.rb
@@ -1,5 +1,5 @@
 module FakeFS
-  class FakeDir < Hash
+  class FakeDir
     attr_accessor :name, :parent, :mode, :uid, :gid
     attr_reader :ctime, :mtime, :atime, :content
 
@@ -13,6 +13,7 @@ module FakeFS
       @uid     = Process.uid
       @gid     = Process.gid
       @content = ""
+      @entries = {}
     end
 
     def entry
@@ -20,12 +21,12 @@ module FakeFS
     end
 
     def inspect
-      "(FakeDir name:#{name.inspect} parent:#{parent.to_s.inspect} size:#{size})"
+      "(FakeDir name:#{name.inspect} parent:#{parent.to_s.inspect} size:#{@entries.size})"
     end
 
     def clone(parent = nil)
       clone = Marshal.load(Marshal.dump(self))
-      clone.each do |key, value|
+      clone.entries.each do |value|
         value.parent = clone
       end
       clone.parent = parent if parent
@@ -42,11 +43,31 @@ module FakeFS
       end
     end
 
+    def empty?
+      @entries.empty?
+    end
+
+    def entries
+      @entries.values
+    end
+
+    def matches(pattern)
+      @entries.reject {|k,v| pattern !~ k }.values
+    end
+
+    def [](name)
+      @entries[name]
+    end
+
+    def []=(name, value)
+      @entries[name] = value
+    end
+
     def delete(node = self)
       if node == self
         parent.delete(self)
       else
-        super(node.name)
+        @entries.delete(node.name)
       end
     end
   end

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -16,7 +16,7 @@ module FakeFS
     end
 
     def files
-      fs.values
+      fs.entries
     end
 
     def find(path)
@@ -114,17 +114,16 @@ module FakeFS
         when ['*']
           parts = [] # end recursion
           directories_under(dir).map do |d|
-            d.values.select{|f| f.is_a?(FakeFile) || f.is_a?(FakeDir) }
+            d.entries.select{|f| f.is_a?(FakeFile) || f.is_a?(FakeDir) }
           end.flatten.uniq
         when []
           parts = [] # end recursion
-          dir.values.flatten.uniq
+          dir.entries.flatten.uniq
         else
           directories_under(dir)
         end
       else
-        regexp_pattern = /\A#{pattern.gsub('?','.').gsub('*', '.*').gsub(/\{(.*?)\}/) { "(#{$1.gsub(',', '|')})" }}\Z/
-        dir.reject {|k,v| regexp_pattern !~ k }.values
+        dir.matches /\A#{pattern.gsub('?','.').gsub('*', '.*').gsub(/\{(.*?)\}/) { "(#{$1.gsub(',', '|')})" }}\Z/
       end
 
       if parts.empty? # we're done recursing
@@ -135,7 +134,7 @@ module FakeFS
     end
 
     def directories_under(dir)
-      children = dir.values.select{|f| f.is_a? FakeDir}
+      children = dir.entries.select{|f| f.is_a? FakeDir}
       ([dir] + children + children.map{|c| directories_under(c)}).flatten.uniq
     end
   end

--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -23,7 +23,7 @@ module FakeFS
         parent.pop
         raise Errno::ENOENT, "No such file or directory - #{l}" unless parent.join == "" || FileSystem.find(parent.join('/'))
         raise Errno::ENOENT, l unless FileSystem.find(l)
-        raise Errno::ENOTEMPTY, l unless FileSystem.find(l).values.empty?
+        raise Errno::ENOTEMPTY, l unless FileSystem.find(l).empty?
         rm(l)
       end
     end
@@ -101,7 +101,7 @@ module FakeFS
         # about and cleaned up.
         if new_dir
           if src[-2..-1] == '/.'
-            dir.values.each{|f| new_dir[f.name] = f.clone(new_dir) }
+            dir.entries.each{|f| new_dir[f.name] = f.clone(new_dir) }
           else
             new_dir[dir.name] = dir.entry.clone(new_dir)
           end


### PR DESCRIPTION
In particular, this fixes a problem on Rubinius, where Hash#reject is
implemented in terms of Hash#delete, and overriding #delete with non-standard
semantics causes #reject to fail.
