### PR TITLE
adds pathname.rb to the files to be copied

### DIFF
--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
     "lib/fakefs.rb",
     "lib/fakefs/base.rb",
     "lib/fakefs/dir.rb",
+    "lib/fakefs/pathname.rb",
     "lib/fakefs/fake/dir.rb",
     "lib/fakefs/fake/file.rb",
     "lib/fakefs/fake/symlink.rb",


### PR DESCRIPTION
If the ruby version is >=1.9.3, fakefs/safe requires pathname.rb.  This file wasn't in the list of files to copy in the gemspec so I added it.
