### PR TITLE
Fixes a bug triggered by calling File.directory? with a filename containing a period

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -123,7 +123,7 @@ module FakeFS
           directories_under(dir)
         end
       else
-        dir.matches /\A#{pattern.gsub('?','.').gsub('*', '.*').gsub(/\{(.*?)\}/) { "(#{$1.gsub(',', '|')})" }}\Z/
+        dir.matches /\A#{pattern.gsub('?','.').gsub('*', '.*').gsub('.', '\.').gsub(/\{(.*?)\}/) { "(#{$1.gsub(',', '|')})" }}\Z/
       end
 
       if parts.empty? # we're done recursing


### PR DESCRIPTION
Fixes a bug in FileSystem.find_recurser where supplying a filename containing a "." results in that "." being treated as a wild-card by the file-finding regular expression(s).  This bug was causing an "undefined method entry" exception to be thrown in File.directory? since FileSystem.find was unexpectedly returning an array if more than one file matched the spurious wildcard.
