### PR TITLE
Changed a == at the end of a test for hard links to an assertion.

### DIFF
--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1815,7 +1815,7 @@ class FakeFSTest < Test::Unit::TestCase
     File.link("/foo", "/bar")
 
     File.unlink("/bar")
-    File.read("/foo") == "some_content"
+    assert_equal "some_content", File.read("/foo")
   end
 
   def test_link_reports_correct_stat_info_after_unlinking


### PR DESCRIPTION
I noticed that there was a test with no assertions, so I modified the line that appeared to be intended as an assertion.
