### PR TITLE
File.read accepts multiple parameters.

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -149,7 +149,7 @@ module FakeFS
       symlink.target
     end
 
-    def self.read(path)
+    def self.read(path, *args)
       file = new(path)
       if file.exists?
         FileSystem.find(path).atime = Time.now

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -412,6 +412,15 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal "Yatta!", File.read(path)
   end
 
+  def test_file_read_accepts_hashes
+    path = 'file.txt'
+    File.open(path, 'w') do |f|
+      f.write 'Yatta!'
+    end
+
+    assert_nothing_raised { File.read(path, :mode => 'r:UTF-8:-') }
+  end
+
   def test_can_write_to_files
     path = 'file.txt'
     File.open(path, 'w') do |f|


### PR DESCRIPTION
File.read raises errors if it is called with multiple parameters. I ran across this when using fakefs to handle testing some logic around gem and gemspec manipulation. Gem::Specification.load was calling File.read with a second parameter. The call in the test was actually taken directly from Gem::Specification.load.
