### PR TITLE
Correct typos in fakefs_test.rb that accidentally aliased a couple of tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 pkg
 Gemfile.lock
 .rbenv-version
+.idea
+.bundle

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -55,12 +55,12 @@ class FakeFSTest < Test::Unit::TestCase
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
   end
 
-  def test_can_create_directories_with_mkpath
+  def test_can_create_directories_with_mkdirs
     FileUtils.makedirs("/path/to/dir")
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
   end
 
-  def test_can_create_directories_with_mkpath_and_options
+  def test_can_create_directories_with_mkdirs_and_options
     FileUtils.makedirs("/path/to/dir", :mode => 0755)
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
   end


### PR DESCRIPTION
- Also, gitignore the RubyMine and Bundle directories.
