### PR TITLE
File::Stat needs #readable?, #writable? and #zero? methods

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -296,6 +296,10 @@ module FakeFS
           File.size(@file)
         end
       end
+
+      def zero?
+        size == 0
+      end
     end
 
     attr_reader :path

--- a/test/file/stat_test.rb
+++ b/test/file/stat_test.rb
@@ -82,4 +82,12 @@ class FileStatTest < Test::Unit::TestCase
     File.open('testfile', 'w') { |f| f << 'test' }
     assert_equal 4, File.stat('testfile').size
   end
+
+  def test_file_zero?
+    File.open('testfile', 'w') { |f| f << 'test' }
+    refute File.stat('testfile').zero?, "testfile has size 4, not zero"
+
+    FileUtils.touch('testfile2')
+    assert File.stat('testfile2').zero?, "testfile2 has size 0, but stat lied"
+  end
 end


### PR DESCRIPTION
I needed these query methods when I started using fakefs in my own projects to replace testing against the real FS. `#readable?` and `#writable?` are hard-coded to `true`, as seen elsewhere in the codebase. 
