### PR TITLE
fix for issues #77

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -23,8 +23,8 @@ module FakeFS
                    RealFile::EXCL     |
                    RealFile::NONBLOCK |
                    RealFile::TRUNC    |
-                   RealFile::NOCTTY   |
-                   RealFile::SYNC
+                   (RealFile.const_defined?(:NOCTTY) ? RealFile::NOCTTY : 0)   |
+                   (RealFile.const_defined?(:SYNC) ? RealFile::SYNC : 0)
 
     FILE_CREATION_BITMASK = RealFile::CREAT
 


### PR DESCRIPTION
File::SYNC and File::NOCTTY are not defined in ruby on Windows, so I've added conditions to not use them.
