### PR TITLE
Dir.glob does not work with absolute path after clone

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -91,7 +91,10 @@ module FakeFS
     end
 
     def self.glob(pattern, &block)
-      matches_for_pattern = lambda { |matcher| [FileSystem.find(matcher) || []].flatten.map{|e| Dir.pwd.match(%r[\A/?\z]) ? e.to_s : e.to_s.match(%r[\A#{Dir.pwd}/?]).post_match}.sort  }
+      matches_for_pattern = lambda do |matcher|
+        [FileSystem.find(matcher) || []].flatten.map{|e|
+          Dir.pwd.match(%r[\A/?\z]) || !e.to_s.match(%r[\A#{Dir.pwd}/?]) ? e.to_s : e.to_s.match(%r[\A#{Dir.pwd}/?]).post_match}.sort
+      end
 
       if pattern.is_a? Array
         files = pattern.collect { |matcher| matches_for_pattern.call matcher }.flatten

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1273,6 +1273,14 @@ class FakeFSTest < Test::Unit::TestCase
     act_on_real_fs { RealFileUtils.rm_rf(here('subdir')) }
   end
 
+  def test_dir_glob_on_clone_with_absolute_path
+    act_on_real_fs { RealFileUtils.mkdir_p(here('subdir/.bar/baz/.quux/foo')) }
+    FileUtils.mkdir_p '/path'
+    Dir.chdir('/path')
+    FileSystem.clone(here('subdir'), "/foo")
+    assert Dir.glob "/foo/*"
+  end
+
   def test_clone_with_target_specified
     act_on_real_fs { RealFileUtils.mkdir_p(here('subdir/.bar/baz/.quux/foo')) }
 


### PR DESCRIPTION
NoMethodError: undefined method `post_match' for nil:NilClass is thrown on calling Dir.glob when absolute path is used on clonned directory
