### PR TITLE
Fix for issue #150: we should not mock PATH_SEPARATOR

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -2,8 +2,6 @@ require 'stringio'
 
 module FakeFS
   class File < StringIO
-    PATH_SEPARATOR = '/'
-
     MODES = [
       READ_ONLY           = "r",
       READ_WRITE          = "r+",

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -86,7 +86,7 @@ module FakeFS
     end
 
     def path_parts(path)
-      path.split(File::PATH_SEPARATOR).reject { |part| part.empty? }
+      path.split(File::SEPARATOR).reject { |part| part.empty? }
     end
 
     def normalize_path(path)


### PR DESCRIPTION
I've removed mock for PATH_SEPARATOR and changed FileSystem to use File::SEPARATOR instead
