### PR TITLE
FileUtils.mv should overwrite files

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -115,6 +115,7 @@ module FakeFS
       Array(src).each do |path|
         if target = FileSystem.find(path)
           dest_path = File.directory?(dest) ? File.join(dest, File.basename(path)) : dest
+          FileSystem.delete(dest_path)
           FileSystem.add(dest_path, target.entry.clone)
           FileSystem.delete(path)
         else

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1093,6 +1093,13 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal 'bar', File.open('baz') { |f| f.read }
   end
 
+  def test_mv_overwrites_existing_files
+    File.open('foo', 'w') { |f| f.write 'bar' }
+    File.open('baz', 'w') { |f| f.write 'qux' }
+    FileUtils.mv 'foo', 'baz'
+    assert_equal 'bar', File.read('baz')
+  end
+
   def test_mv_works_with_options
     File.open('foo', 'w') {|f| f.write 'bar'}
     FileUtils.mv 'foo', 'baz', :force => true


### PR DESCRIPTION
`FakeFS::FileUtils.mv` should overwrite files, but currently doesn't:

``` ruby
FakeFS do
  File.open('first', 'w') { |f| f.write 'content first' }
  File.open('second', 'w') { |f| f.write 'content second' }
  FileUtils.mv('first', 'second')

  File.read('second') # should return "content first"
  # => "content second"
end
```

This commit changes FakeFS::FileUtils.mv so that target files are overwritten correctly.
