### PR TITLE
Add support for FileUtils#remove_entry_secure

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -37,6 +37,7 @@ module FakeFS
     alias_method :rm_rf, :rm
     alias_method :rm_r, :rm
     alias_method :rm_f, :rm
+    alias_method :remove_entry_secure, :rm
 
     def ln_s(target, path, options = {})
       options = { :force => false }.merge(options)


### PR DESCRIPTION
Hello,

This is my first pull request on github, so I hope everything is done well.
I have just added an alias named "remove_entry_secure" onto "rm".
This allow to support this method of FileUtils.
I di not try to simulate the chown and chmod behavior mentionned in ruby official doc for this method. As far as I understand FakeFS, this is not necessary to fake it.

Cheers,
