### PR TITLE
Added the options hash to mkdir in FileUtils

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -8,7 +8,7 @@ module FakeFS
     alias_method :mkpath, :mkdir_p
     alias_method :makedirs, :mkdir_p
 
-    def mkdir(path)
+    def mkdir(path, options = {})
       parent = path.split('/')
       parent.pop
       raise Errno::ENOENT, "No such file or directory - #{path}" unless parent.join == "" || parent.join == "." || FileSystem.find(parent.join('/'))


### PR DESCRIPTION
The following code was initially failing:
`FileUtils.mkdir tmp_dir, :mode => 0700`

So I modified the FileUtils#mkdir function to accept an options hash.  The function does nothing with the hash as I don't think a concept of MODE exists in fakefs for a directory, but at least it gets rid of the "wrong number of arguments (2 for 1)" exception.
