### PR TITLE
FileUtils.move alias for FileUtils.mv

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -123,6 +123,7 @@ module FakeFS
         end
       end
     end
+    alias_method :move, :mv
 
     def chown(user, group, list, options={})
       list = Array(list)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1134,6 +1134,10 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal('binky', File.open('destdir/baz') {|f| f.read })
   end
 
+  def test_move_is_alias_for_mv
+    assert_equal FileUtils.method(:move), FileUtils.method(:mv)
+  end
+
   def test_cp_actually_works
     File.open('foo', 'w') {|f| f.write 'bar' }
     FileUtils.cp('foo', 'baz')


### PR DESCRIPTION
FileUtils.move is an alias for FileUtils.mv ( See [Ruby doc](http://ruby-doc.org/stdlib-2.0/libdoc/fileutils/rdoc/FileUtils.html#method-c-move) )
