### PR TITLE
(Small change) Allow FakeFS::FileUtils.cd to accept a block.

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -193,8 +193,8 @@ module FakeFS
       end
     end
 
-    def cd(dir)
-      FileSystem.chdir(dir)
+    def cd(dir, &block)
+      FileSystem.chdir(dir, &block)
     end
     alias_method :chdir, :cd
   end


### PR DESCRIPTION
This seems to be the cause of #142 and possibly #176.

Simply allows the `FakeFS::FileUtils.cd` method to accept a block.
