### PR TITLE
List argument for FileUtils.mkdir and FileUtils.mkdir_p

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -2,18 +2,24 @@ module FakeFS
   module FileUtils
     extend self
 
-    def mkdir_p(path, options = {})
-      FileSystem.add(path, FakeDir.new)
+    def mkdir_p(list, options = {})
+      list = [ list ] unless list.is_a?(Array)
+      list.each do |path|
+        FileSystem.add(path, FakeDir.new)
+      end
     end
     alias_method :mkpath, :mkdir_p
     alias_method :makedirs, :mkdir_p
 
-    def mkdir(path)
-      parent = path.split('/')
-      parent.pop
-      raise Errno::ENOENT, "No such file or directory - #{path}" unless parent.join == "" || parent.join == "." || FileSystem.find(parent.join('/'))
-      raise Errno::EEXIST, "File exists - #{path}" if FileSystem.find(path)
-      FileSystem.add(path, FakeDir.new)
+    def mkdir(list)
+      list = [ list ] unless list.is_a?(Array)
+      list.each do |path|
+        parent = path.split('/')
+        parent.pop
+        raise Errno::ENOENT, "No such file or directory - #{path}" unless parent.join == "" || parent.join == "." || FileSystem.find(parent.join('/'))
+        raise Errno::EEXIST, "File exists - #{path}" if FileSystem.find(path)
+        FileSystem.add(path, FakeDir.new)
+      end
     end
 
     def rmdir(list, options = {})

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -28,6 +28,12 @@ class FakeFSTest < Test::Unit::TestCase
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
   end
 
+  def test_can_create_a_list_of_directories_with_file_utils_mkdir_p
+    FileUtils.mkdir_p(["/path/to/dir1", "/path/to/dir2"])
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir1']
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir2']
+  end
+
   def test_can_create_directories_with_options
     FileUtils.mkdir_p("/path/to/dir", :mode => 0755)
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
@@ -37,6 +43,13 @@ class FakeFSTest < Test::Unit::TestCase
     FileUtils.mkdir_p("/path/to/dir")
     FileUtils.mkdir("/path/to/dir/subdir")
     assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']['subdir']
+  end
+
+  def test_can_create_a_list_of_directories_with_file_utils_mkdir
+    FileUtils.mkdir_p("/path/to/dir")
+    FileUtils.mkdir(["/path/to/dir/subdir1", "/path/to/dir/subdir2"])
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']['subdir1']
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']['subdir2']
   end
 
   def test_raises_error_when_creating_a_new_dir_with_mkdir_in_non_existent_path


### PR DESCRIPTION
According to the [Ruby Doc](http://www.ruby-doc.org/stdlib-1.8.7/libdoc/fileutils/rdoc/FileUtils.html#method-c-mkdir), `mkdir` and `mkdir_p` can also take a list of directories as argument. I updated the fake methods to handle this (inspired from the existing code in `rmdir`).
