### PR TITLE
Set File mtime via FileUtils.touch using options[:mtime] hash

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -206,7 +206,7 @@ module FakeFS
         else
           f = File.open(f, 'w')
           f.close
-          FileSystem.find(f).mtime(mtime) if mtime
+          FileSystem.find(f).mtime = mtime if mtime
         end
       end
     end


### PR DESCRIPTION
FileUtils.touch options hash can accept an :mtime parameter that will set a File's mtime. This PR sets the mtime based on the hash param.

http://www.ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-touch
