### PR TITLE
Add FileUtils copy_file method.

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -95,6 +95,11 @@ module FakeFS
 
     alias_method :copy, :cp
 
+    def copy_file(src, dest, preserve = false, dereference = true)
+      # Not a perfect match, but similar to what regular FileUtils does.
+      cp(src, dest)
+    end
+
     def cp_r(src, dest, options={})
       Array(src).each do |src|
         # This error sucks, but it conforms to the original Ruby

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1284,6 +1284,12 @@ class FakeFSTest < Test::Unit::TestCase
     end
   end
 
+  def test_copy_file_works
+    File.open('foo', 'w') {|f| f.write 'bar' }
+    FileUtils.copy_file('foo', 'baz', :ignore_param_1, :ignore_param_2)
+    assert_equal 'bar', File.read('baz')
+  end
+
   def test_cp_r_doesnt_tangle_files_together
     File.open('foo', 'w') { |f| f.write 'bar' }
     FileUtils.cp_r('foo', 'baz')


### PR DESCRIPTION
Was getting failures with rack v1.4.5 (same issues exist from 1.3.0 to 1.4.5).

```
     Failure/Error: Rack::Utils::Multipart::UploadedFile.new(file_path, "text/plain")
     NoMethodError:
       private method `copy_file' called for FakeFS::FileUtils:Module
```

https://github.com/rack/rack/blob/master/lib/rack/multipart/uploaded_file.rb#L17

FileUtils.copy_file is defined as a public method (at least in Ruby 1.8.7).  

To fix this, I added the copy_file method (which accepts 2 additional params besides src and dest.)
See:
https://github.com/ruby/ruby/blob/ruby_1_8_7/lib/fileutils.rb#L462

The two additional params will just get ignored, but it looks like FileUtils cp definition only takes 2 args instead a third (options) arg, so I didn't think that'd be an issue.
