### PR TITLE
Fixed expand_path to use working directory set by chdir

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -134,8 +134,9 @@ module FakeFS
       end
     end
 
-    def self.expand_path(*args)
-      RealFile.expand_path(*args)
+    def self.expand_path(file_name, *args)
+      args = [ FileSystem.current_dir.to_s ] if args.empty?
+      RealFile.expand_path(file_name, *args)
     end
 
     def self.basename(*args)

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -47,7 +47,7 @@ module FakeFS
     # copies directories and files from the real filesystem
     # into our fake one
     def clone(path, target = nil)
-      path    = File.expand_path(path)
+      path    = RealFile.expand_path(path)
       pattern = File.join(path, '**', '*')
       files   = RealFile.file?(path) ? [path] : [path] + RealDir.glob(pattern, RealFile::FNM_DOTMATCH)
 
@@ -91,15 +91,15 @@ module FakeFS
 
     def normalize_path(path)
       if Pathname.new(path).absolute?
-        File.expand_path(path)
+        RealFile.expand_path(path)
       else
         parts = dir_levels + [path]
-        File.expand_path(File.join(*parts))
+        RealFile.expand_path(File.join(*parts))
       end
     end
 
     def current_dir
-      find(normalize_path('.'))
+      find('.')
     end
 
     private
@@ -107,7 +107,7 @@ module FakeFS
     def drop_root(path_parts)
       # we need to remove parts from root dir at least for windows and jruby
       return path_parts if path_parts.nil? || path_parts.empty?
-      root = File.expand_path('/').split(File::SEPARATOR).first
+      root = RealFile.expand_path('/').split(File::SEPARATOR).first
       path_parts.shift if path_parts.first == root
       path_parts
     end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1221,6 +1221,20 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal '/path/subdir', Dir.getwd
   end
 
+  def test_current_dir_reflected_by_expand_path
+    FileUtils.mkdir_p '/path'
+    Dir.chdir '/path'
+
+    assert_equal '/path', File.expand_path('.')
+    assert_equal '/path/foo', File.expand_path('foo')
+
+    FileUtils.mkdir_p 'subdir'
+    Dir.chdir 'subdir'
+
+    assert_equal '/path/subdir', File.expand_path('.')
+    assert_equal '/path/subdir/foo', File.expand_path('foo')
+  end
+
   def test_file_open_defaults_to_read
     File.open('foo','w') { |f| f.write 'bar' }
     assert_equal 'bar', File.open('foo') { |f| f.read }


### PR DESCRIPTION
`File.expand_path` with one argument should expand from the current working directory. However, it seems that it keeps using the working directory of the real file system instead of the fake one set by `Dir.chdir`. I added a test for this and updated the code, but I am unsure of the impact of my changes. The test suite says I haven't broken anything, so that's a good sign.
