### PR TITLE
Make File.size return bytes instead of char count.

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -89,7 +89,7 @@ module FakeFS
     end
 
     def self.size(path)
-      read(path).length
+      read(path).bytesize
     end
 
     def self.size?(path)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -520,6 +520,14 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal 9, File.size(path)
   end
 
+  def test_can_get_correct_size_for_files_with_multibyte_characters
+    path = 'file.txt'
+    File.open(path, 'wb') do |f|
+      f << "Y\xC3\xA1da" # Yáda
+    end
+    assert_equal 5, File.size(path)
+  end
+
   def test_can_check_if_file_has_size?
     path = 'file.txt'
     File.open(path, 'w') do |f|


### PR DESCRIPTION
Found this while writing xml with utf8 chars out, then using File.size to get the length.  IO.read returns a string and calling .length returns the number of characters in the string.  Using .bytesize instead of length fixes the problem.
