### PR TITLE
Add ruby 2.0.0 to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0
   - jruby
   - rbx-19mode
 matrix:
   allow_failures:
+    - rvm: 2.0.0
     - rvm: jruby
     - rvm: rbx-19mode


### PR DESCRIPTION
Hi. Ruby 2.0.0 was released and my project uses fakefs on ruby 2.0.0. It works great for me :smile:

I propose to add ruby 2.0.0 to travis CI. It allows failure at this time.
Thanks.
