### PR TITLE
Allow reading and writing files with the IO class

### DIFF
--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -18,12 +18,14 @@ module FakeFS
         remove_const(:File)
         remove_const(:FileTest)
         remove_const(:FileUtils)
+        remove_const(:IO)
         remove_const(:Pathname) if RUBY_VERSION >= "1.9.3"
 
         const_set(:Dir,       FakeFS::Dir)
         const_set(:File,      FakeFS::File)
         const_set(:FileUtils, FakeFS::FileUtils)
         const_set(:FileTest,  FakeFS::FileTest)
+        const_set(:IO,        FakeFS::IO)
         const_set(:Pathname,  FakeFS::Pathname) if RUBY_VERSION >= "1.9.3"
       end
       true

--- a/lib/fakefs/io.rb
+++ b/lib/fakefs/io.rb
@@ -1,0 +1,14 @@
+module FakeFS
+  class IO < IO
+    def self.write(file_name, content)
+      File.open(file_name, 'w') do |file|
+        file.write(content)
+      end
+    end
+
+    def self.read(file_name)
+      File.open(file_name, 'rb').read
+    end
+   end
+end
+

--- a/lib/fakefs/safe.rb
+++ b/lib/fakefs/safe.rb
@@ -9,5 +9,6 @@ require 'fakefs/fileutils'
 require 'fakefs/file'
 require 'fakefs/file_test'
 require 'fakefs/dir'
+require 'fakefs/io'
 require 'fakefs/pathname' if RUBY_VERSION >= "1.9.3"
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -487,6 +487,13 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal 'Yada Yada', File.read(path)
   end
 
+  def test_can_write_to_files_using_io
+    path = 'file.txt'
+    IO.write(path, 'Yada Yada')
+
+    assert_equal 'Yada Yada', File.read(path)
+  end
+
   def test_raises_error_when_opening_with_binary_mode_only
     assert_raise ArgumentError do
       File.open("/foo", "b")
@@ -768,6 +775,15 @@ class FakeFSTest < Test::Unit::TestCase
     end
 
     assert_equal "Yatta!", File.new(path).read
+  end
+
+  def test_can_read_using_io
+    path = 'file.txt'
+    File.open(path, 'w') do |f|
+      f.write "Yatta!"
+    end
+
+    assert_equal "Yatta!", IO.read(path)
   end
 
   if RUBY_VERSION >= "1.9"


### PR DESCRIPTION
This allows you to use the [IO class](http://ruby-doc.org/core-2.0.0/IO.html) to read and write files to the fake file system.  Not sure if there is a better way to do this but this worked for my use case. Thanks for fakefs!
