### PR TITLE
Fix Dir.foreach with relative paths.

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -9,7 +9,7 @@ module FakeFS
     def initialize(string)
       self.class._check_for_valid_file(string)
 
-      @path = string
+      @path = FileSystem.normalize_path(string)
       @open = true
       @pointer = 0
       @contents = [ '.', '..', ] + FileSystem.find(@path).entries
@@ -44,7 +44,13 @@ module FakeFS
       raise IOError, "closed directory" if @pointer == nil
       n = @contents[@pointer]
       @pointer += 1
-      n.to_s.gsub(path + '/', '') if n
+      if n
+        if n.to_s[0, path.size+1] == path+'/'
+          n.to_s[path.size+1..-1]
+        else
+          n.to_s
+        end
+      end
     end
 
     def rewind

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1774,6 +1774,26 @@ class FakeFSTest < Test::Unit::TestCase
     test.each { |t| assert yielded.include?(t) }
   end
 
+  def test_directory_foreach_relative_paths
+    test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5' ]
+
+    FileUtils.mkdir_p('/this/path/should/be/here')
+
+    test.each do |f|
+      FileUtils.touch("/this/path/should/be/here/#{f}")
+    end
+
+    yielded = []
+    Dir.chdir '/this/path/should/be' do
+      Dir.foreach('here') do |dir|
+        yielded << dir
+      end
+    end
+
+    assert yielded.size == test.size, 'wrong number of files yielded'
+    test.each { |t| assert yielded.include?(t), "#{t} was not included in #{yielded.inspect}" }
+  end
+
   def test_directory_mkdir
     Dir.mkdir('/path')
     assert File.exists?('/path')


### PR DESCRIPTION
`Dir#read` gets contents that are the full path (e.g. /path/to/file.txt) and then strips off the path of the directory (e.g. /path/to) before returning them (e.g. file.txt). This works fine when `Dir#path` is absolute, but not when it is relative. For example, this should print out "file.txt" but it was previously printing "/path/file.txt":

``` ruby
FileUtils.mkdir_p("/path/to")
File.open("/path/to/file.txt", "w") {|f| f << '' }
Dir.chdir("/path") do
  Dir.foreach("to") do |file|
    puts file
  end
end
```

The fix was to always store the normalized path as the `Dir` path when it is initialized. In addition I changed it to stop using the dubious `gsub` in favor of something that actually checks that it starts with the path.
