### PR TITLE
Fix Dir.entries on ruby-2.1.0-preview2

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -80,7 +80,7 @@ module FakeFS
       FileSystem.delete(string)
     end
 
-    def self.entries(dirname)
+    def self.entries(dirname, opts = {})
       _check_for_valid_file(dirname)
 
       Dir.new(dirname).map { |file| File.basename(file) }

--- a/spec/fakefs/fakefs_bug_ruby_2.1.0-preview2.rb
+++ b/spec/fakefs/fakefs_bug_ruby_2.1.0-preview2.rb
@@ -1,0 +1,15 @@
+require 'find'
+require 'fakefs/spec_helpers'
+
+RSpec.configure do |c|
+  c.mock_with(:rspec)
+  c.include(FakeFS::SpecHelpers, :fakefs => true)
+end
+
+describe 'Find.find', :fakefs => true do
+  it 'does not give an ArgumentError' do
+    FileUtils.mkdir_p('/tmp/foo')
+    found = Find.find('/tmp').to_a
+    expect(found).to eq(%w(/tmp /tmp/foo))
+  end
+end


### PR DESCRIPTION
Ruby 2.1.0's `Dir.entries` method now allows an "encoding" option.  Without this change, `ArgumentError: wrong number of arguments (2 for 1)` is raised.

See also http://ruby-doc.org/core-2.1.0/Dir.html

I found this while [working on Ruby 2.1.0 compatibility for Maid](https://github.com/benjaminoakes/maid/issues/114).  As a part of debugging Maid's specs, I extracted a minimal spec that demonstrates the problem.  It's currently in `spec/fakefs/fakefs_bug_ruby_2.1.0-preview2.rb`.

Thanks for maintaining FakeFS.  It makes Maid's specs much easier to write!

Ben
