### PR TITLE
Updated method signature for FakeFS::FakeSymlink#respond_to?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org/'
 
 gemspec
+
+group :development do
+  gem 'minitest', '~> 4.7'
+end

--- a/lib/fakefs/fake/symlink.rb
+++ b/lib/fakefs/fake/symlink.rb
@@ -22,8 +22,8 @@ module FakeFS
       File.join(parent.to_s, name)
     end
 
-    def respond_to?(method)
-      entry.respond_to?(method)
+    def respond_to?(*params)
+      entry.respond_to?(*params)
     end
 
   private

--- a/test/fake/symlink_test.rb
+++ b/test/fake/symlink_test.rb
@@ -7,4 +7,19 @@ class FakeSymlinkTest < Test::Unit::TestCase
     methods = FakeSymlink.private_instance_methods.map { |m| m.to_s }
     assert methods.include?("method_missing")
   end
+
+  def test_symlink_respond_to_accepts_multiple_params
+    fake_symlink = FakeSymlink.new('foo')
+    assert fake_symlink.respond_to?(:to_s, false), 'has public method \#to_s'
+    assert fake_symlink.respond_to?(:to_s, true), 'has public or private method \#to_s'
+    assert !fake_symlink.respond_to?(:initialize, false), 'has private method \#initialize'
+    assert fake_symlink.respond_to?(:initialize, true), 'has private method \#initialize'
+  end
+
+  def test_symlink_respond_to_uses_same_param_defaults
+    fake_symlink = FakeSymlink.new('foo')
+    assert_equal fake_symlink.respond_to?(:to_s), fake_symlink.entry.respond_to?(:to_s)
+    assert_not_equal fake_symlink.respond_to?(:to_s), fake_symlink.entry.respond_to?(:initialize)
+    assert_equal fake_symlink.respond_to?(:initialize), fake_symlink.entry.respond_to?(:initialize)
+  end
 end


### PR DESCRIPTION
- Old version only accepted one parameter, which was no longer correct
  as of Ruby 1.8.7 (or, for that matter, 1.8.6 - I can't tell when the second
  parameter was added to the signature).
- Test suite validates the method accepts both parameters and that
  the behavior is implemented correctly.  It also validates that the
  default values are resolved correctly.  Note that the change in
  behavior in Ruby 2.0.0 for the second parameter was implemented by
  modifying the meaning of the second parameter (from `include_priv`
  to `include_all`) rather than changing the default value (which
  remained `false`), but it is still better not to copy method
  signatures if possible.
