### PR TITLE
Update spec_helper documentation for latest rspec

### DIFF
--- a/lib/fakefs/spec_helpers.rb
+++ b/lib/fakefs/spec_helpers.rb
@@ -18,7 +18,7 @@
 #
 #   require 'fakefs/spec_helpers'
 #
-#   Spec::Runner.configure do |config|
+#   RSpec.configure do |config|
 #     config.include FakeFS::SpecHelpers
 #   end
 #


### PR DESCRIPTION
Just a quick doco fix. Old version is using a deprecated api.
