### PR TITLE
Kernel open hijacking

### DIFF
--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -35,6 +35,7 @@ module FakeFS
         const_set(:FileUtils, FakeFS::FileUtils)
         const_set(:FileTest,  FakeFS::FileTest)
         const_set(:Pathname,  FakeFS::Pathname) if RUBY_VERSION >= "1.9.3"
+        ::FakeFS::Kernel.hijack!
       end
       true
     end
@@ -54,6 +55,7 @@ module FakeFS
         const_set(:FileTest,  RealFileTest)
         const_set(:FileUtils, RealFileUtils)
         const_set(:Pathname,  RealPathname) if RUBY_VERSION >= "1.9.3"
+        ::FakeFS::Kernel.unhijack!
       end
       true
     end

--- a/lib/fakefs/kernel.rb
+++ b/lib/fakefs/kernel.rb
@@ -1,0 +1,40 @@
+module FakeFS
+  module Kernel
+
+    @captives = { :original => {}, :hijacked => {}}
+    class << self
+      attr_accessor :captives
+    end
+
+    def self.hijack!
+      captives[:hijacked].each do |name,prc|
+        ::Kernel.send(:define_method, name.to_sym, &prc)
+      end
+    end
+
+    def self.unhijack!
+      captives[:original].each do |name,prc|
+        ::Kernel.send(:define_method, name.to_sym, Proc.new do |*args, &block|
+          ::FakeFS::Kernel.captives[:original][name].call(*args, &block)
+        end)
+      end
+    end
+
+    private
+    def self.hijack name, &block
+      captives[:original][name] = ::Kernel.method(name.to_sym)
+      captives[:hijacked][name] = block || Proc.new { |args| }
+    end
+
+    hijack :open do |*args, &block|
+      if args.first.start_with? '|'
+        # This is a system command
+        ::FakeFS::Kernel.captives[:original][:open].call(*args, &block)
+      else
+        name, rest = *args
+        FakeFS::File.open(name, *rest, &block)
+      end
+    end
+
+  end
+end

--- a/lib/fakefs/safe.rb
+++ b/lib/fakefs/safe.rb
@@ -10,4 +10,4 @@ require 'fakefs/file'
 require 'fakefs/file_test'
 require 'fakefs/dir'
 require 'fakefs/pathname' if RUBY_VERSION >= "1.9.3"
-
+require 'fakefs/kernel'

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class KernelTest < Test::Unit::TestCase
+  include FakeFS
+  def setup
+    FakeFS.deactivate!
+  end
+
+  def teardown
+    FakeFS.activate!
+  end
+
+  def test_can_exec_normally
+    out = open("|echo 'foo'")
+    assert_equal "foo\n", out.gets
+  end
+
+  def test_fake_kernel_can_create_subprocesses
+    FakeFS do
+      out = open("|echo 'foo'")
+      assert_equal "foo\n", out.gets
+    end
+  end
+
+  def test_fake_kernel_can_create_new_file
+    FakeFS do
+      FileUtils.mkdir_p '/path/to/'
+      open('/path/to/file', "w") do |f|
+        f << "test"
+      end
+      assert_kind_of FakeFile, FileSystem.fs['path']['to']['file']
+    end
+  end
+
+  def test_fake_kernel_can_do_stuff
+    FakeFS do
+      FileUtils.mkdir_p('/tmp')
+      File.open('/tmp/a', 'w+') { |f| f.puts 'test' }
+
+      begin
+      puts open('/tmp/a').read
+      rescue Exception => e
+        puts e
+        puts e.backtrace
+        raise e
+      end
+    end
+  end
+
+  def test_can_exec_normally2
+    out = open("|echo 'foo'")
+    assert_equal "foo\n", out.gets
+  end
+
+end
+


### PR DESCRIPTION
It seems that FakeFS cannot handle open-uri on files.

``` ruby
require 'open-uri'
require 'fakefs/safe'

describe 'fakefs and open-uri' do
  before(:each) { FakeFS.activate! }
  after(:each) { FakeFS.deactivate! }

  it 'can read files' do
    FileUtils.mkdir_p '/tmp'
    File.open('/tmp/a.b', 'w+') { |f| f.puts 'test' }

    data = File.read('/tmp/a.b')
    expect(data).to match('test')
  end

  it 'can open-uri files' do
    FileUtils.mkdir_p '/tmp'
    File.open('/tmp/a.b', 'w+') { |f| f.puts 'test' }

    begin
      open('/tmp/a.b').read
    rescue Exception => e
      puts e
      puts e.backtrace
      raise e
    end
    expect(data).to match('test')
  end
end

```

```
No such file or directory - /tmp/a.b
/Users/jacob/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/open-uri.rb:36:in `initialize'
/Users/jacob/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/open-uri.rb:36:in `open'
...
Failures:

  1) fakefs and open-uri can open-uri files
     Failure/Error: open('/tmp/a.b').read
     Errno::ENOENT:
       No such file or directory - /tmp/a.b
     # ./test_spec.rb:20:in `block (2 levels) in <top (required)>'

Finished in 0.0035 seconds
2 examples, 1 failure
```

This [issue](https://github.com/defunkt/fakefs/issues/22) is related. `Kernel#open` is monkey patched by `open-uri` but it eventually fails on the original implementation being called.
