### PR TITLE
Remove rdiscount from Gemspec

### DIFF
--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rdiscount"
 end


### PR DESCRIPTION
### Why?
- Rdiscount is not used
- It's listed as a development dependency
- Rdicount uses C-extensions - JRuby bundle exec cannot be run
- Travis tests fail for JRuby because of this

Related:
https://github.com/defunkt/fakefs/issues/217
