### PR TITLE
Changed behaviour of File.delete to allow no arguments, like the actual File.delete

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -209,18 +209,16 @@ module FakeFS
       0
     end
 
-    def self.delete(file_name, *additional_file_names)
-      if !exists?(file_name)
-        raise Errno::ENOENT, file_name
-      end
+    def self.delete(*file_names)
+      file_names.each do |file_name|
+        if !exists?(file_name)
+          raise Errno::ENOENT, file_name
+        end
 
-      FileUtils.rm(file_name)
-
-      additional_file_names.each do |file_name|
         FileUtils.rm(file_name)
       end
 
-      additional_file_names.size + 1
+      file_names.size
     end
 
     class << self

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2200,10 +2200,8 @@ class FakeFSTest < Test::Unit::TestCase
     assert !File.exists?("/bar")
   end
 
-  def test_delete_raises_argument_error_with_no_filename_given
-    assert_raises ArgumentError do
-      File.delete
-    end
+  def test_delete_returns_zero_when_no_filename_given
+    assert_equal 0, File.delete
   end
 
   def test_delete_returns_number_one_when_given_one_arg


### PR DESCRIPTION
I tested File.delete on Ruby 2.1.1, Ruby 1.9.2 and Ruby 1.8.7 and a call with no arguments to `File.delete` just returns 0.
