### PR TITLE
Make File#rename work as expected

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -177,6 +177,8 @@ module FakeFS
         raise Errno::ENOTDIR, "#{source} or #{dest}"
       elsif file?(source) && directory?(dest)
         raise Errno::EISDIR, "#{source} or #{dest}"
+      elsif !exist?(dirname(dest))
+        raise Errno::ENOENT, "#{source} or #{dest}"
       end
 
       if target = FileSystem.find(source)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require "test_helper"
 
 class FakeFSTest < Test::Unit::TestCase
@@ -2131,6 +2132,13 @@ class FakeFSTest < Test::Unit::TestCase
   def test_rename_with_missing_source_raises_error
     assert_raises(Errno::ENOENT) do
       File.rename("/no_such_file", "/bar")
+    end
+  end
+
+  def test_rename_with_missing_dest_directory_raises_error
+    FileUtils.touch("/foo")
+    assert_raises(Errno::ENOENT) do
+      File.rename("/foo", "/bar/foo")
     end
   end
 


### PR DESCRIPTION
Standard Ruby File class #rename raises Errno::ENOENT if the destination directory does not exist.

```
irb(main):003:0>
irb(main):003:0> File.open("/tmp/test", "w") { |f| f.write("hello") }
=> 5
irb(main):004:0> File.rename("/tmp/test", "/tmp/dir/test")
Errno::ENOENT: No such file or directory - /tmp/test or /tmp/dir/test
    from (irb):4:in `rename'
    from (irb):4
    from :0
irb(main):005:0>
```

This patch implements this edge behaviour in FakeFS.
