### PR TITLE
Clean up tests and organize them into appropriate files

### DIFF
--- a/test/dir/glob_test.rb
+++ b/test/dir/glob_test.rb
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+require "test_helper"
+
+class DirGlobTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def test_dir_glob_finds_exact_match_directories
+    setup_directories
+
+    assert_equal ['/path'], Dir['/path']
+    assert_equal ['/path/foo'], Dir['/path/foo']
+  end
+
+  def test_dir_glob_matches_wildcard_in_directory
+    setup_directories
+
+    assert_equal %w( /path/bar /path/bar2 /path/foo /path/foobar ), Dir['/path/*']
+    assert_equal ['/path/bar/baz'], Dir['/path/bar/*']
+  end
+
+  def test_dir_glob_matches_wildcard_in_filename
+    setup_directories
+
+    assert_equal ['/path'], Dir['/path*']
+    assert_equal ['/path/foo', '/path/foobar'], Dir['/p*h/foo*']
+  end
+
+  def test_dir_glob_matches_single_wildcard_in_filename
+    setup_directories
+
+    assert_equal ['/path/foo', '/path/foobar'], Dir['/p??h/foo*']
+  end
+
+  def test_dir_glob_matches_double_wildcard_for_nested_directories
+    setup_directories
+
+    assert_equal ['/path/bar', '/path/bar/baz', '/path/bar2', '/path/bar2/baz', '/path/foo', '/path/foobar'], Dir['/path/**/*']
+    assert_equal ['/path', '/path/bar', '/path/bar/baz', '/path/bar2', '/path/bar2/baz', '/path/foo', '/path/foobar'], Dir['/**/*']
+
+    assert_equal ['/path/bar', '/path/bar/baz', '/path/bar2', '/path/bar2/baz', '/path/foo', '/path/foobar'], Dir['/path/**/*']
+    assert_equal ['/path/bar/baz'], Dir['/path/bar/**/*']
+
+    assert_equal ['/path/bar/baz', '/path/bar2/baz'], Dir['/path/bar/**/*', '/path/bar2/**/*']
+    assert_equal ['/path/bar/baz', '/path/bar2/baz', '/path/bar/baz'], Dir['/path/ba*/**/*', '/path/bar/**/*']
+  end
+
+  def test_glob_handles_wildcard_root
+    setup_directories
+    FileUtils.cp_r '/path', '/otherpath'
+
+    assert_equal %w(/otherpath/foo /otherpath/foobar /path/foo /path/foobar), Dir['/*/foo*']
+  end
+
+  def test_glob_handles_bracketed_options
+    setup_directories
+
+    assert_equal ['/path/bar', '/path/foo'], Dir['/path/{foo,bar}']
+    assert_equal ['/path/bar', '/path/bar2'], Dir['/path/bar{2,}']
+  end
+
+  def test_glob_works_after_chdir
+    setup_directories
+
+    Dir.chdir '/path' do
+      assert_equal ['foo'], Dir['foo']
+    end
+  end
+
+  private
+
+  def setup_directories
+    FileUtils.mkdir_p '/path'
+    touch_files ['/path/foo', '/path/foobar']
+
+    FileUtils.mkdir_p '/path/bar'
+    touch_file '/path/bar/baz'
+
+    FileUtils.cp_r '/path/bar', '/path/bar2'
+  end
+end

--- a/test/dir_test.rb
+++ b/test/dir_test.rb
@@ -1,0 +1,347 @@
+# -*- coding: utf-8 -*-
+require "test_helper"
+
+class DirTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  # Directory tests
+  def test_new_directory
+    FileUtils.mkdir_p(sample_nested_dir)
+
+    assert_nothing_raised do
+      Dir.new(sample_nested_dir)
+    end
+  end
+
+  def test_new_directory_does_not_work_if_dir_path_cannot_be_found
+    assert_raises(Errno::ENOENT) do
+      Dir.new('/this/path/should/not/be/here')
+    end
+  end
+
+  def test_directory_close
+    FileUtils.mkdir_p(sample_nested_dir)
+    dir = Dir.new(sample_nested_dir)
+    assert dir.close.nil?
+
+    assert_raises(IOError) do
+      dir.each { |dir| dir }
+    end
+  end
+
+  def test_directory_path
+    FileUtils.mkdir_p(sample_nested_dir)
+    good_path = sample_nested_dir
+    assert_equal good_path, Dir.new(sample_nested_dir).path
+  end
+
+  def test_directory_class_delete_does_not_work_if_dir_path_cannot_be_found
+    assert_raises(Errno::ENOENT) do
+      Dir.delete('/this/path/should/not/be/here')
+    end
+  end
+
+  def test_directory_class_delete
+    FileUtils.mkdir_p(sample_nested_dir)
+    Dir.delete(sample_nested_dir)
+    assert_equal false, File.exists?(sample_nested_dir)
+  end
+
+  # =================== BEGIN BLOCK ======================
+  def files
+    default_files + sample_filenames
+  end
+
+  def sample_nested_dir
+    '/this/path/should/be/here'
+  end
+
+  def test_directory_each
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    yielded = []
+    dir.each { |file| yielded << file }
+
+    assert_equal yielded.size, files.size
+    files.each { |t| assert yielded.include?(t) }
+  end
+
+  def test_directory_pos
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    assert_equal dir.pos, 0
+    dir.read
+    assert_equal dir.pos, 1
+    dir.read
+    assert_equal dir.pos, 2
+    dir.read
+    assert_equal dir.pos, 3
+    dir.read
+    assert_equal dir.pos, 4
+    dir.read
+    assert_equal dir.pos, 5
+  end
+
+  def test_directory_pos_assign
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    assert_equal dir.pos, 0
+    dir.pos = 2
+    assert_equal dir.pos, 2
+  end
+
+  def test_directory_read
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    assert_equal dir.pos, 0
+    d = dir.read
+    assert_equal dir.pos, 1
+    assert_equal d, '.'
+
+    d = dir.read
+    assert_equal dir.pos, 2
+    assert_equal d, '..'
+  end
+
+  def test_directory_read_past_length
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_not_nil d
+    d = dir.read
+    assert_nil d
+  end
+
+  def test_directory_rewind
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    d = dir.read
+    d = dir.read
+    assert_equal dir.pos, 2
+    dir.rewind
+    assert_equal dir.pos, 0
+  end
+
+  def test_directory_seek
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.new(sample_nested_dir)
+
+    d = dir.seek 1
+    assert_equal d, '..'
+    assert_equal dir.pos, 1
+  end
+
+  def test_directory_class_delete_does_not_act_on_non_empty_directory
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    assert_raises(Errno::ENOTEMPTY) do
+      Dir.delete(sample_nested_dir)
+    end
+  end
+
+  def test_directory_entries
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    yielded = Dir.entries(sample_nested_dir)
+    assert_equal yielded.size, files.size
+    files.each { |t| assert yielded.include?(t) }
+  end
+
+  def test_directory_entries_works_with_trailing_slash
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    yielded = Dir.entries('/this/path/should/be/here/')
+    assert_equal yielded.size, files.size
+    files.each { |t| assert yielded.include?(t) }
+  end
+
+  def test_directory_foreach_relative_paths
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    yielded = []
+    Dir.chdir '/this/path/should/be' do
+      Dir.foreach('here') { |file| yielded << file }
+    end
+
+    assert_equal yielded.size, files.size, 'wrong number of files yielded'
+    files.each { |t| assert yielded.include?(t), "#{t} was not included in #{yielded.inspect}" }
+  end
+
+  def test_directory_foreach
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files sample_filenames, :dir => sample_nested_dir
+
+    yielded = []
+    Dir.foreach(sample_nested_dir) { |file| yielded << file }
+
+    assert_equal yielded.size, files.size
+    sample_filenames.each { |f| assert yielded.include?(f) }
+  end
+
+  def test_directory_open
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    dir = Dir.open(sample_nested_dir)
+    assert_equal dir.path, sample_nested_dir
+  end
+
+  def test_directory_open_block
+    FileUtils.mkdir_p(sample_nested_dir)
+    touch_files files, :dir => sample_nested_dir
+
+    yielded = []
+    Dir.open(sample_nested_dir) { |file| yielded << file }
+
+    assert_equal yielded.size, files.size
+    files.each { |t| assert yielded.include?(t) }
+  end
+
+  def sample_filenames
+    %w{file_1 file_2 file_3 file_4 file_5}
+  end
+
+  def default_files
+    ['.', '..']
+  end
+  # ============================ END BLOCK ========================
+
+  def test_directory_entries_does_not_work_if_dir_path_cannot_be_found
+    assert_raises(Errno::ENOENT) do
+      Dir.delete('/this/path/should/not/be/here')
+    end
+  end
+
+  def test_directory_mkdir
+    Dir.mkdir('/path')
+    assert File.exists?('/path')
+  end
+
+  def test_directory_mkdir_nested
+    Dir.mkdir("/tmp")
+    Dir.mkdir("/tmp/stream20120103-11847-xc8pb.lock")
+    assert File.exists?("/tmp/stream20120103-11847-xc8pb.lock")
+  end
+
+  def test_can_create_subdirectories_with_dir_mkdir
+    Dir.mkdir 'foo'
+    Dir.mkdir 'foo/bar'
+    assert Dir.exists?('foo/bar')
+  end
+
+  def test_can_create_absolute_subdirectories_with_dir_mkdir
+    Dir.mkdir '/foo'
+    Dir.mkdir '/foo/bar'
+    assert Dir.exists?('/foo/bar')
+  end
+
+  def test_can_create_directories_starting_with_dot
+    Dir.mkdir './path'
+    assert File.exists? './path'
+  end
+
+  def test_directory_mkdir_relative
+    FileUtils.mkdir_p('/new/root')
+    FileSystem.chdir('/new/root')
+    Dir.mkdir('path')
+    assert File.exists?('/new/root/path')
+  end
+
+  def test_directory_mkdir_not_recursive
+    assert_raises(Errno::ENOENT) do
+      Dir.mkdir('/path/does/not/exist')
+    end
+  end
+
+  def test_mkdir_raises_error_if_already_created
+    Dir.mkdir "foo"
+
+    assert_raises(Errno::EEXIST) do
+      Dir.mkdir "foo"
+    end
+  end
+
+  def test_directory_exists
+    assert_equal Dir.exists?(sample_nested_dir), false
+    assert_equal Dir.exist?(sample_nested_dir), false
+    FileUtils.mkdir_p(sample_nested_dir)
+    assert_equal Dir.exists?(sample_nested_dir), true
+    assert_equal Dir.exist?(sample_nested_dir), true
+  end
+
+  def test_tmpdir
+    assert_equal Dir.tmpdir, "/tmp"
+  end
+
+  def test_chdir_shouldnt_lose_state_because_of_errors
+    FileUtils.mkdir_p '/path'
+
+    Dir.chdir '/path' do
+      File.open('foo', 'w') { |f| f.write 'foo'}
+      File.open('foobar', 'w') { |f| f.write 'foo'}
+    end
+
+    begin
+      Dir.chdir('/path') do
+        raise Exception
+      end
+    rescue Exception # hardcore
+    end
+
+    Dir.chdir('/path') do
+      begin
+        Dir.chdir('nope'){ }
+      rescue Errno::ENOENT
+      end
+
+      assert_equal ['/', '/path'], FileSystem.dir_levels
+    end
+
+    assert_equal(['/path/foo', '/path/foobar'], Dir.glob('/path/*').sort)
+  end
+end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -746,14 +746,11 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal '/', FileSystem.fs.name
     assert_equal [], Dir.glob('/path/*')
     Dir.chdir '/path' do
-      File.write 'foo', 'foo'
-      touch_file 'foobar'
+      touch_file 'foo'
     end
 
     assert_equal '/', FileSystem.fs.name
-    assert_exist ['/path/foo', '/path/foobar']
-
-    assert_equal 'foo', File.read('/path/foo')
+    assert_exists '/path/foo'
   end
 
   def test_chdir_shouldnt_keep_us_from_absolute_paths

--- a/test/file_utils/chmod_test.rb
+++ b/test/file_utils/chmod_test.rb
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+require "test_helper"
+
+class ChmodTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+    FileUtils.touch(good)
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def good
+    'file.txt'
+  end
+
+  def bad
+    'nofile.txt'
+  end
+
+  def test_can_chmod_files
+    assert_equal [good], FileUtils.chmod(0600, good, :verbose => true)
+    assert_equal File.stat(good).mode, 0100600
+    assert_equal File.executable?(good), false
+  end
+
+  def test_cannot_chmod_nonexistant_file
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chmod(0600, bad)
+    end
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chmod(0666, bad)
+    end
+  end
+
+  def test_giving_everyone_permissions
+    assert_equal [good], FileUtils.chmod(0666, good)
+    assert_equal File.stat(good).mode, 0100666
+  end
+
+  def test_chmodding_multiple_existant_files
+    FileUtils.touch('good2')
+    assert_equal [good, 'good2'], FileUtils.chmod(0644, [good, 'good2'])
+    assert_equal File.stat(good).mode, 0100644
+    assert_equal File.stat('good2').mode, 0100644
+  end
+
+  def test_cannot_chmod_multiple_files_if_some_dont_exist
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chmod(0644, [good, bad])
+    end
+  end
+
+  def test_setting_file_to_executable
+    assert_equal [good], FileUtils.chmod(0744, [good])
+    assert_equal File.executable?(good), true
+  end
+
+  def test_setting_file_to_nonexecutable
+    # This behaviour is unimplemented, the spec below is only to show that it
+    # is a deliberate YAGNI omission.
+    assert_equal [good], FileUtils.chmod(0477, [good])
+    assert_equal File.executable?(good), false
+  end
+
+  def test_can_chmod_R_files
+    FileUtils.mkdir_p "/path/sub"
+    FileUtils.touch "/path/file1"
+    FileUtils.touch "/path/sub/file2"
+
+    assert_equal ["/path"], FileUtils.chmod_R(0600, "/path")
+    assert_equal File.stat("/path").mode, 0100600
+    assert_equal File.stat("/path/file1").mode, 0100600
+    assert_equal File.stat("/path/sub").mode, 0100600
+    assert_equal File.stat("/path/sub/file2").mode, 0100600
+
+    FileUtils.mkdir_p "/path2"
+    FileUtils.touch "/path2/hej"
+    assert_equal ["/path2"], FileUtils.chmod_R(0600, "/path2")
+  end
+end

--- a/test/file_utils/chown_test.rb
+++ b/test/file_utils/chown_test.rb
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+require "test_helper"
+
+class ChownTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+    FileUtils.touch good
+    FileUtils.chown(original_user_id, original_group_id, good)
+  end
+
+  def original_user_id
+    1337
+  end
+
+  def original_group_id
+    1338
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def username
+    Etc.getpwuid(Process.uid).name
+  end
+
+  def groupname
+    Etc.getgrgid(Process.gid).name
+  end
+
+  def good
+    'file.txt'
+  end
+
+  def bad
+    'nofile.txt'
+  end
+
+  def test_can_chown_existing_files_with_uid_and_gid
+    out = FileUtils.chown(30, 31, good)
+    assert_equal [good], out
+    assert_equal File.stat(good).uid, 30
+    assert_equal File.stat(good).gid, 31
+  end
+
+  def test_cannot_chown_nonexistant_files_with_uid_and_gid
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chown(username, groupname, bad, :verbose => true)
+    end
+  end
+
+  def test_can_chown_existing_files_with_username_and_groupname
+    assert_equal [good], FileUtils.chown(username, groupname, good)
+    assert_ids_match_process good
+  end
+
+  def test_cannot_chown_nonexistant_files_with_username_and_groupname
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chown(username, groupname, bad)
+    end
+  end
+
+  def test_can_chown_multiple_existing_files
+    files = %w(good1 good2)
+    files.each {|f| FileUtils.touch f }
+
+    assert_equal files, FileUtils.chown(username, groupname, files)
+    files.each {|f| assert_ids_match_process f }
+  end
+
+  def test_cannot_chown_multiple_files_if_some_dont_exist
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chown(username, groupname, [good, bad])
+    end
+  end
+
+  def test_chown_with_nil_user_and_nil_group_does_not_change_anything
+    FileUtils.chown(username, groupname, good)
+    assert_ids_match_process good
+
+    assert_equal [good], FileUtils.chown(nil, nil, [good])
+    assert_ids_match_process good
+  end
+
+  def test_chown_with_nil_user_and_nil_group_errors_on_nonexistant_file
+    assert_raises(Errno::ENOENT) do
+      FileUtils.chown(nil, nil, [good, bad])
+    end
+  end
+
+  def test_can_chown_R_files
+    FileUtils.mkdir_p '/path/'
+    FileUtils.touch('/path/foo')
+    FileUtils.touch('/path/foobar')
+
+    assert_equal ['/path'], FileUtils.chown_R(username, groupname, '/path')
+    %w(/path /path/foo /path/foobar).each do |file|
+      assert_ids_match_process file
+    end
+  end
+
+  def assert_ids_match_process file
+    assert_equal File.stat(file).uid, Process.uid
+    assert_equal File.stat(file).gid, Process.gid
+  end
+end

--- a/test/file_utils_test.rb
+++ b/test/file_utils_test.rb
@@ -1,0 +1,599 @@
+# -*- coding: utf-8 -*-
+require "test_helper"
+
+class FileUtilsTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def test_can_create_directories_with_file_utils_mkdir_p
+    FileUtils.mkdir_p("/path/to/dir")
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_can_cd_to_directory_with_block
+    FileUtils.mkdir_p("/path/to/dir")
+    new_path = nil
+    FileUtils.cd("/path/to") do
+      new_path = Dir.getwd
+    end
+
+    assert_equal new_path, "/path/to"
+  end
+
+  def test_can_create_a_list_of_directories_with_file_utils_mkdir_p
+    FileUtils.mkdir_p(["/path/to/dir1", "/path/to/dir2"])
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir1']
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir2']
+  end
+
+  def test_can_create_directories_with_options
+    FileUtils.mkdir_p("/path/to/dir", :mode => 0755)
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_can_create_directories_with_file_utils_mkdir
+    FileUtils.mkdir_p("/path/to/dir")
+    FileUtils.mkdir("/path/to/dir/subdir")
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']['subdir']
+  end
+
+  def test_can_create_a_list_of_directories_with_file_utils_mkdir
+    FileUtils.mkdir_p("/path/to/dir")
+    FileUtils.mkdir(["/path/to/dir/subdir1", "/path/to/dir/subdir2"])
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']['subdir1']
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']['subdir2']
+  end
+
+  def test_raises_error_when_creating_a_new_dir_with_mkdir_in_non_existent_path
+    assert_raises Errno::ENOENT do
+      FileUtils.mkdir("/this/path/does/not/exists/newdir")
+    end
+  end
+
+  def test_raises_error_when_creating_a_new_dir_over_existing_file
+    File.open("file", "w") {|f| f << "This is a file, not a directory." }
+
+    assert_raise Errno::EEXIST do
+      FileUtils.mkdir_p("file/subdir")
+    end
+
+    FileUtils.mkdir("dir")
+    File.open("dir/subfile", "w") {|f| f << "This is a file inside a directory." }
+
+    assert_raise Errno::EEXIST do
+      FileUtils.mkdir_p("dir/subfile/subdir")
+    end
+  end
+
+  def test_can_create_directories_with_mkpath
+    FileUtils.mkpath("/path/to/dir")
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_can_create_directories_with_mkpath_and_options
+    FileUtils.mkpath("/path/to/dir", :mode => 0755)
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_can_create_directories_with_mkdirs
+    FileUtils.makedirs("/path/to/dir")
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_can_create_directories_with_mkdirs_and_options
+    FileUtils.makedirs("/path/to/dir", :mode => 0755)
+    assert_kind_of FakeDir, FileSystem.fs['path']['to']['dir']
+  end
+
+  def test_unlink_errors_on_file_not_found
+    assert_raise Errno::ENOENT do
+      FileUtils.rm("/foo")
+    end
+  end
+
+  def test_unlink_doesnt_error_on_file_not_found_when_forced
+    assert_nothing_raised do
+      FileUtils.rm("/foo", :force => true)
+    end
+  end
+
+  def test_can_delete_directories
+    FileUtils.mkdir_p("/path/to/dir")
+    FileUtils.rmdir("/path/to/dir")
+    assert File.exists?("/path/to/")
+    assert_equal File.exists?("/path/to/dir"), false
+  end
+
+  def test_can_delete_multiple_files
+    FileUtils.touch(["foo", "bar"])
+    FileUtils.rm(["foo", "bar"])
+    assert_equal File.exists?("foo"), false
+    assert_equal File.exists?("bar"), false
+  end
+
+  def test_aliases_exist
+    assert File.respond_to?(:unlink)
+    assert FileUtils.respond_to?(:rm_f)
+    assert FileUtils.respond_to?(:rm_r)
+    assert FileUtils.respond_to?(:rm)
+    assert FileUtils.respond_to?(:rm_rf)
+    assert FileUtils.respond_to?(:symlink)
+    assert FileUtils.respond_to?(:move)
+    assert FileUtils.respond_to?(:copy)
+    assert FileUtils.respond_to?(:remove)
+    assert FileUtils.respond_to?(:rmtree)
+    assert FileUtils.respond_to?(:safe_unlink)
+    assert FileUtils.respond_to?(:remove_entry_secure)
+    assert FileUtils.respond_to?(:cmp)
+    assert FileUtils.respond_to?(:identical?)
+  end
+
+  def test_knows_directories_exist
+    FileUtils.mkdir_p(path = "/path/to/dir")
+    assert File.exists?(path)
+  end
+
+  def test_knows_directories_are_directories
+    FileUtils.mkdir_p(path = "/path/to/dir")
+    assert File.directory?(path)
+  end
+
+  def test_knows_directories_are_directories_with_periods
+    FileUtils.mkdir_p(period_path = "/path/to/periodfiles/one.one")
+    FileUtils.mkdir("/path/to/periodfiles/one-one")
+
+    assert File.directory?(period_path)
+  end
+
+  def test_knows_symlink_directories_are_directories
+    FileUtils.mkdir_p(path = "/path/to/dir")
+    FileUtils.ln_s path, sympath = '/sympath'
+    assert File.directory?(sympath)
+  end
+
+  def test_knows_non_existent_directories_arent_directories
+    path = 'does/not/exist/'
+    assert_equal RealFile.directory?(path), File.directory?(path)
+  end
+
+  def test_doesnt_overwrite_existing_directories
+    FileUtils.mkdir_p(path = "/path/to/dir")
+    assert File.exists?(path)
+    FileUtils.mkdir_p("/path/to")
+    assert File.exists?(path)
+    assert_raises Errno::EEXIST do
+      FileUtils.mkdir("/path/to")
+    end
+    assert File.exists?(path)
+  end
+
+  def test_file_utils_mkdir_takes_options
+    FileUtils.mkdir("/foo", :some => :option)
+    assert File.exists?("/foo")
+  end
+
+  def test_can_create_symlinks
+    FileUtils.mkdir_p(target = "/path/to/target")
+    FileUtils.ln_s(target, "/path/to/link")
+    assert_kind_of FakeSymlink, FileSystem.fs['path']['to']['link']
+
+    assert_raises(Errno::EEXIST) do
+      FileUtils.ln_s(target, '/path/to/link')
+    end
+  end
+
+  def test_can_force_creation_of_symlinks
+    FileUtils.mkdir_p(target = "/path/to/first/target")
+    FileUtils.ln_s(target, "/path/to/link")
+    assert_kind_of FakeSymlink, FileSystem.fs['path']['to']['link']
+    FileUtils.ln_s(target, '/path/to/link', :force => true)
+  end
+
+  def test_create_symlink_using_ln_sf
+    FileUtils.mkdir_p(target = "/path/to/first/target")
+    FileUtils.ln_s(target, "/path/to/link")
+    assert_kind_of FakeSymlink, FileSystem.fs['path']['to']['link']
+    FileUtils.ln_sf(target, '/path/to/link')
+  end
+
+  def test_can_follow_symlinks
+    FileUtils.mkdir_p(target = "/path/to/target")
+    FileUtils.ln_s(target, link = "/path/to/symlink")
+    assert_equal target, File.readlink(link)
+  end
+
+  def test_symlinks_in_different_directories
+    FileUtils.mkdir_p("/path/to/bar")
+    FileUtils.mkdir_p(target = "/path/to/foo/target")
+
+    FileUtils.ln_s(target, link = "/path/to/bar/symlink")
+    assert_equal target, File.readlink(link)
+  end
+
+  def test_symlink_with_relative_path_exists
+    FileUtils.touch("/file")
+    FileUtils.mkdir_p("/a/b")
+    FileUtils.ln_s("../../file", link = "/a/b/symlink")
+    assert File.exist?('/a/b/symlink')
+  end
+
+  def test_symlink_with_relative_path_and_nonexistant_file_does_not_exist
+    FileUtils.touch("/file")
+    FileUtils.mkdir_p("/a/b")
+    FileUtils.ln_s("../../file_foo", link = "/a/b/symlink")
+    assert !File.exist?('/a/b/symlink')
+  end
+
+  def test_symlink_with_relative_path_has_correct_target
+    FileUtils.touch("/file")
+    FileUtils.mkdir_p("/a/b")
+    FileUtils.ln_s("../../file", link = "/a/b/symlink")
+    assert_equal "../../file", File.readlink(link)
+  end
+
+  def test_symlinks_to_symlinks
+    FileUtils.mkdir_p(target = "/path/to/foo/target")
+    FileUtils.mkdir_p("/path/to/bar")
+    FileUtils.mkdir_p("/path/to/bar2")
+
+    FileUtils.ln_s(target, link1 = "/path/to/bar/symlink")
+    FileUtils.ln_s(link1, link2 = "/path/to/bar2/symlink")
+    assert_equal link1, File.readlink(link2)
+  end
+
+  def test_symlink_to_symlinks_should_raise_error_if_dir_doesnt_exist
+    FileUtils.mkdir_p(target = "/path/to/foo/target")
+
+    assert !Dir.exists?("/path/to/bar")
+
+    assert_raise Errno::ENOENT do
+      FileUtils.ln_s(target, "/path/to/bar/symlink")
+    end
+  end
+
+  def test_knows_symlinks_are_symlinks
+    FileUtils.mkdir_p(target = "/path/to/target")
+    FileUtils.ln_s(target, link = "/path/to/symlink")
+    assert File.symlink?(link)
+  end
+
+  if RUBY_VERSION >= "1.9"
+    def test_can_set_mtime_on_new_file_touch_with_param
+      time = Time.new(2002, 10, 31, 2, 2, 2, "+02:00")
+      FileUtils.touch("foo.txt", :mtime => time)
+
+      assert_equal File.mtime("foo.txt"), time
+    end
+
+    def test_can_set_mtime_on_existing_file_touch_with_param
+      FileUtils.touch("foo.txt")
+
+      time = Time.new(2002, 10, 31, 2, 2, 2, "+02:00")
+      FileUtils.touch("foo.txt", :mtime => time)
+
+      assert_equal File.mtime("foo.txt"), time
+    end
+  end
+
+  def test_file_utils_cp_allows_noop_option
+    File.open('foo', 'w') {|f| f << 'TEST' }
+    FileUtils.cp 'foo', 'bar', :noop => true
+    assert !File.exist?('bar'), 'does not actually copy'
+  end
+
+  def test_file_utils_cp_raises_on_invalid_option
+    assert_raises ArgumentError do
+      FileUtils.cp 'foo', 'bar', :whatisthis => "I don't know"
+    end
+  end
+
+  def test_file_utils_cp_r_allows_verbose_option
+    FileUtils.touch "/foo"
+    assert_equal "cp -r /foo /bar\n", capture_stderr { FileUtils.cp_r '/foo', '/bar', :verbose => true }
+  end
+
+  def test_file_utils_cp_r_allows_noop_option
+    FileUtils.touch "/foo"
+    FileUtils.cp_r '/foo', '/bar', :noop => true
+    assert !File.exist?('/bar'), 'does not actually copy'
+  end
+
+  def test_copy_with_subdirectory
+    FileUtils.mkdir_p "/one/two/three/"
+    FileUtils.mkdir_p "/onebis/two/three/"
+    FileUtils.touch "/one/two/three/foo"
+    Dir.glob("/one/two/three/*") do |hook|
+      FileUtils.cp(hook, "/onebis/two/three/")
+    end
+    assert_equal ['/onebis/two/three/foo'], Dir['/onebis/two/three/*']
+  end
+
+  def test_mv_should_raise_error_on_missing_file
+    assert_raise(Errno::ENOENT) do
+      FileUtils.mv 'blafgag', 'foo'
+    end
+    exception = assert_raise(Errno::ENOENT) do
+      FileUtils.mv ['foo', 'bar'], 'destdir'
+    end
+    assert_equal "No such file or directory - foo", exception.message
+  end
+
+  def test_mv_actually_works
+    File.open('foo', 'w') { |f| f.write 'bar' }
+    FileUtils.mv 'foo', 'baz'
+    assert_equal 'bar', File.open('baz') { |f| f.read }
+  end
+
+  def test_mv_overwrites_existing_files
+    File.open('foo', 'w') { |f| f.write 'bar' }
+    File.open('baz', 'w') { |f| f.write 'qux' }
+    FileUtils.mv 'foo', 'baz'
+    assert_equal 'bar', File.read('baz')
+  end
+
+  def test_mv_works_with_options
+    File.open('foo', 'w') {|f| f.write 'bar'}
+    FileUtils.mv 'foo', 'baz', :force => true
+    assert_equal('bar', File.open('baz') { |f| f.read })
+  end
+
+  def test_mv_to_directory
+    File.open('foo', 'w') {|f| f.write 'bar'}
+    FileUtils.mkdir_p 'destdir'
+    FileUtils.mv 'foo', 'destdir'
+    assert_equal('bar', File.open('destdir/foo') {|f| f.read })
+    assert File.directory?('destdir')
+  end
+
+  def test_mv_array
+    File.open('foo', 'w') {|f| f.write 'bar' }
+    File.open('baz', 'w') {|f| f.write 'binky' }
+    FileUtils.mkdir_p 'destdir'
+    FileUtils.mv %w(foo baz), 'destdir'
+    assert_equal('bar', File.open('destdir/foo') {|f| f.read })
+    assert_equal('binky', File.open('destdir/baz') {|f| f.read })
+  end
+
+  def test_mv_accepts_verbose_option
+    FileUtils.touch 'foo'
+    assert_equal "mv foo bar\n", capture_stderr { FileUtils.mv 'foo', 'bar', :verbose => true }
+  end
+
+  def test_mv_accepts_noop_option
+    FileUtils.touch 'foo'
+    FileUtils.mv 'foo', 'bar', :noop => true
+    assert File.exist?('foo'), 'does not remove src'
+    assert !File.exist?('bar'), 'does not create target'
+  end
+
+  def test_mv_raises_when_moving_file_onto_directory
+    FileUtils.mkdir_p 'dir/stuff'
+    FileUtils.touch 'stuff'
+    assert_raises Errno::EEXIST do
+      FileUtils.mv 'stuff', 'dir'
+    end
+  end
+
+  def test_mv_raises_when_moving_to_non_existent_directory
+    FileUtils.touch 'stuff'
+    assert_raises Errno::ENOENT do
+      FileUtils.mv 'stuff', '/this/path/is/not/here'
+    end
+  end
+
+  def test_mv_ignores_failures_when_using_force
+    FileUtils.mkdir_p 'dir/stuff'
+    FileUtils.touch %w[stuff other]
+    FileUtils.mv %w[stuff other], 'dir', :force => true
+    assert File.exist?('stuff'), 'failed move remains where it was'
+    assert File.exist?('dir/other'), 'successful one is moved'
+    assert !File.exist?('other'), 'successful one is moved'
+
+    FileUtils.mv 'stuff', '/this/path/is/not/here', :force => true
+    assert File.exist?('stuff'), 'failed move remains where it was'
+    assert !File.exist?('/this/path/is/not/here'), 'nothing is created for a failed move'
+  end
+
+  def test_cp_actually_works
+    File.open('foo', 'w') {|f| f.write 'bar' }
+    FileUtils.cp('foo', 'baz')
+    assert_equal 'bar', File.read('baz')
+  end
+
+  def test_cp_file_into_dir
+    File.open('foo', 'w') {|f| f.write 'bar' }
+    FileUtils.mkdir_p 'baz'
+
+    FileUtils.cp('foo', 'baz')
+    assert_equal 'bar', File.read('baz/foo')
+  end
+
+  def test_cp_array_of_files_into_directory
+    File.open('foo', 'w') { |f| f.write 'footext' }
+    File.open('bar', 'w') { |f| f.write 'bartext' }
+    FileUtils.mkdir_p 'destdir'
+    FileUtils.cp(%w(foo bar), 'destdir')
+
+    assert_equal 'footext', File.read('destdir/foo')
+    assert_equal 'bartext', File.read('destdir/bar')
+  end
+
+  def test_cp_fails_on_array_of_files_into_non_directory
+    File.open('foo', 'w') { |f| f.write 'footext' }
+
+    exception = assert_raise(Errno::ENOTDIR) do
+      FileUtils.cp(%w(foo), 'baz')
+    end
+    assert_equal "Not a directory - baz", exception.to_s
+  end
+
+  def test_cp_overwrites_dest_file
+    File.open('foo', 'w') {|f| f.write 'FOO' }
+    File.open('bar', 'w') {|f| f.write 'BAR' }
+
+    FileUtils.cp('foo', 'bar')
+    assert_equal 'FOO', File.read('bar')
+  end
+
+  def test_cp_fails_on_no_source
+    assert_raise Errno::ENOENT do
+      FileUtils.cp('foo', 'baz')
+    end
+  end
+
+  def test_cp_fails_on_directory_copy
+    FileUtils.mkdir_p 'baz'
+
+    assert_raise Errno::EISDIR do
+      FileUtils.cp('baz', 'bar')
+    end
+  end
+
+  def test_copy_file_works
+    File.open('foo', 'w') {|f| f.write 'bar' }
+    FileUtils.copy_file('foo', 'baz', :ignore_param_1, :ignore_param_2)
+    assert_equal 'bar', File.read('baz')
+  end
+
+  def test_cp_r_doesnt_tangle_files_together
+    File.open('foo', 'w') { |f| f.write 'bar' }
+    FileUtils.cp_r('foo', 'baz')
+    File.open('baz', 'w') { |f| f.write 'quux' }
+    assert_equal 'bar', File.open('foo') { |f| f.read }
+  end
+
+  def test_cp_r_should_raise_error_on_missing_file
+    # Yes, this error sucks, but it conforms to the original Ruby
+    # method.
+    assert_raise(RuntimeError) do
+      FileUtils.cp_r 'blafgag', 'foo'
+    end
+  end
+
+  def test_cp_r_handles_copying_directories
+    FileUtils.mkdir_p 'subdir'
+    Dir.chdir('subdir'){ File.open('foo', 'w') { |f| f.write 'footext' } }
+
+    FileUtils.mkdir_p 'baz'
+
+    # To a previously uncreated directory
+    FileUtils.cp_r('subdir', 'quux')
+    assert_equal 'footext', File.open('quux/foo') { |f| f.read }
+
+    # To a directory that already exists
+    FileUtils.cp_r('subdir', 'baz')
+    assert_equal 'footext', File.open('baz/subdir/foo') { |f| f.read }
+
+    # To a subdirectory of a directory that does not exist
+    assert_raises(Errno::ENOENT) do
+      FileUtils.cp_r('subdir', 'nope/something')
+    end
+  end
+
+  def test_cp_r_array_of_files
+    FileUtils.mkdir_p 'subdir'
+    File.open('foo', 'w') { |f| f.write 'footext' }
+    File.open('bar', 'w') { |f| f.write 'bartext' }
+    FileUtils.cp_r(%w(foo bar), 'subdir')
+
+    assert_equal 'footext', File.open('subdir/foo') { |f| f.read }
+    assert_equal 'bartext', File.open('subdir/bar') { |f| f.read }
+  end
+
+  def test_cp_r_array_of_directories
+    %w(foo bar subdir).each { |d| FileUtils.mkdir_p d }
+    File.open('foo/baz', 'w') { |f| f.write 'baztext' }
+    File.open('bar/quux', 'w') { |f| f.write 'quuxtext' }
+
+    FileUtils.cp_r(%w(foo bar), 'subdir')
+    assert_equal 'baztext', File.open('subdir/foo/baz') { |f| f.read }
+    assert_equal 'quuxtext', File.open('subdir/bar/quux') { |f| f.read }
+  end
+
+  def test_cp_r_only_copies_into_directories
+    FileUtils.mkdir_p 'subdir'
+    Dir.chdir('subdir') { File.open('foo', 'w') { |f| f.write 'footext' } }
+
+    File.open('bar', 'w') { |f| f.write 'bartext' }
+
+    assert_raises(Errno::EEXIST) do
+      FileUtils.cp_r 'subdir', 'bar'
+    end
+
+    FileUtils.mkdir_p 'otherdir'
+    FileUtils.ln_s 'otherdir', 'symdir'
+
+    FileUtils.cp_r 'subdir', 'symdir'
+    assert_equal 'footext', File.open('symdir/subdir/foo') { |f| f.read }
+  end
+
+  def test_cp_r_sets_parent_correctly
+    FileUtils.mkdir_p '/path/foo'
+    File.open('/path/foo/bar', 'w') { |f| f.write 'foo' }
+    File.open('/path/foo/baz', 'w') { |f| f.write 'foo' }
+
+    FileUtils.cp_r '/path/foo', '/path/bar'
+
+    assert File.exists?('/path/bar/baz')
+    FileUtils.rm_rf '/path/bar/baz'
+    assert_equal %w( /path/bar/bar ), Dir['/path/bar/*']
+  end
+
+  def test_putting_a_dot_at_end_copies_the_contents
+    FileUtils.mkdir_p 'subdir'
+    Dir.chdir('subdir') { File.open('foo', 'w') { |f| f.write 'footext' } }
+
+    FileUtils.mkdir_p 'newdir'
+    FileUtils.cp_r 'subdir/.', 'newdir'
+    assert_equal 'footext', File.open('newdir/foo') { |f| f.read }
+  end
+
+  def test_files_can_be_touched
+    FileUtils.touch('touched_file')
+    assert File.exists?('touched_file')
+    list = ['newfile', 'another']
+    FileUtils.touch(list)
+    list.each { |fp| assert(File.exists?(fp)) }
+  end
+
+  def test_touch_does_not_work_if_the_dir_path_cannot_be_found
+    assert_raises(Errno::ENOENT) do
+      FileUtils.touch('this/path/should/not/be/here')
+    end
+    FileUtils.mkdir_p('subdir')
+    list = ['subdir/foo', 'nosubdir/bar']
+
+    assert_raises(Errno::ENOENT) do
+      FileUtils.touch(list)
+    end
+  end
+
+  def test_file_utils_compare_file
+    file1 = 'file1.txt'
+    file2 = 'file2.txt'
+    file3 = 'file3.txt'
+    content = "This is my \n file\content\n"
+    File.open(file1, 'w') do |f|
+      f.write content
+    end
+    File.open(file3, 'w') do |f|
+      f.write "#{content} with additional content"
+    end
+
+    FileUtils.cp file1, file2
+
+    assert_equal FileUtils.compare_file(file1, file2), true
+    assert_equal FileUtils.compare_file(file1, file3), false
+    assert_raises Errno::ENOENT do
+      FileUtils.compare_file(file1, "file4.txt")
+    end
+  end
+end

--- a/test/filesystem_test.rb
+++ b/test/filesystem_test.rb
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+require "test_helper"
+
+class FileSystemTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def test_can_be_initialized_empty
+    fs = FileSystem
+    assert_equal 0, fs.files.size
+  end
+
+  def test_can_be_initialized_with_an_existing_directory
+    fs = FileSystem
+    fs.clone(File.expand_path(File.dirname(__FILE__))).inspect
+    assert_equal 1, fs.files.size
+  end
+end

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -32,18 +32,12 @@ class KernelTest < Test::Unit::TestCase
     end
   end
 
-  def test_fake_kernel_can_do_stuff
+  def test_fake_kernel_can_write_and_read
     FakeFS do
       FileUtils.mkdir_p('/tmp')
       File.open('/tmp/a', 'w+') { |f| f.puts 'test' }
 
-      begin
-      puts open('/tmp/a').read
-      rescue Exception => e
-        puts e
-        puts e.backtrace
-        raise e
-      end
+      assert_equal "test\n", open('/tmp/a').read
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,18 @@ def act_on_real_fs
   FakeFS.activate!
 end
 
+def touch_files filenames, options={}
+  dir = options[:dir]
+  filenames.each do |filename|
+    path = dir ? dir + '/' + filename : filename
+    touch_file path
+  end
+end
+
+def touch_file path
+  FileUtils.touch path
+end
+
 def capture_stderr
   real_stderr, $stderr = $stderr, StringIO.new
 


### PR DESCRIPTION
This is a combination of 21 commits, rebased into one. A summary of what was done:

Extract Directory tests to their own file
Begin extracting some FileSystem tests
Extract FileUtils tests to their own file
Remove puts statements from tests
Fix overwritten test names (tests weren't running)
Get rid of bare unicode and binary strings
Continue reorganizing tests
Clean up tests a bit
Move Dir test to appropriate file
Simplify `test_directory_foreach`
Extract raw variables to functions in dir_test
Extract common code to a method
Small syntax change & variable renaming
Use `assert_equal` instead of `assert ... == ...`
Create an `assert_exists` test helper
Extract assert_not_exists helpers
Use `assert_not_equal` when appropriate
Extract `FileUtils.chown` tests to their own file
Extract `touch_file` helpers into `test_helper`
Break dir_glob test into smaller, clearer tests
Break up `chmod` tests into smaller units