### PR TITLE
Unit test for glob regression in 0.5.3

### DIFF
--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1099,6 +1099,12 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal ['/one/five.rb', '/one/two'], Dir['/one/**']
   end
 
+  def test_dir_glob_ending_in_group_and_wildcard
+    FileUtils.mkdir_p "/dir/python-3.4.1"
+    FileUtils.mkdir_p "/dir/python-2.7.8"
+    assert_equal ['/dir/python-2.7.8', '/dir/python-3.4.1'], Dir.glob("/dir/python-[0-9]*")
+  end
+
   def test_dir_glob_with_block
     FileUtils.touch('foo')
     FileUtils.touch('bar')


### PR DESCRIPTION
This includes a new test for a regression that appeared in 0.5.3 when I upgraded today. I'm not familiar enough to know how this regressed since 0.5.2 or how you would like to see this fixed. So this is simply the failing test case.
