### PR TITLE
Add sticky? method for File::Stat

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -316,12 +316,16 @@ module FakeFS
         return 'file'
       end
 
-      # assumes, like above, that all files are readable and writable
+      # assumes, like above, that all files are readable, writable and sticky
       def readable?
         true
       end
 
       def writable?
+        true
+      end
+
+      def sticky?
         true
       end
 

--- a/test/file/stat_test.rb
+++ b/test/file/stat_test.rb
@@ -118,13 +118,16 @@ class FileStatTest < Test::Unit::TestCase
 
   def test_responds_to_world_writable
     FileUtils.touch("/foo")
-    puts File::Stat.new("/foo").world_writable?
     assert File::Stat.new("/foo").world_writable? == 0777
+  end
+
+  def test_responds_to_sticky
+    FileUtils.touch("/foo")
+    assert File::Stat.new("/foo").sticky? == true
   end
 
   def test_responds_to_world_readable
     FileUtils.touch("/foo")
-    puts File::Stat.new("/foo").world_readable?
     assert File::Stat.new("/foo").world_readable? == 0777, "#{File::Stat.new("/foo").world_readable?}"
   end
 

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -38,10 +38,8 @@ class KernelTest < Test::Unit::TestCase
       File.open('/tmp/a', 'w+') { |f| f.puts 'test' }
 
       begin
-      puts open('/tmp/a').read
+      open('/tmp/a').read
       rescue Exception => e
-        puts e
-        puts e.backtrace
         raise e
       end
     end
@@ -53,4 +51,3 @@ class KernelTest < Test::Unit::TestCase
   end
 
 end
-


### PR DESCRIPTION
This method must return true for Dir::Tmpdir method located in tmpdir.rb
file in the ruby source.
This method from original File.stat has been added in ruby >= 2.0.0.
More, I delete some useless 'puts'.

Github issue: #249
