### PR TITLE
Add mode parameter to mkdir_p

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -58,11 +58,13 @@ module FakeFS
         FileSystem.delete(path) or (!options[:force] && raise(Errno::ENOENT.new(path)))
       end
     end
-
-    alias_method :rm_rf, :rm
     alias_method :rm_r, :rm
     alias_method :rm_f, :rm
     alias_method :remove, :rm
+
+    def rm_rf(list, options = {})
+      rm_r(list, options.merge(:force => true))
+    end
     alias_method :rmtree, :rm_rf
     alias_method :safe_unlink, :rm_f
     alias_method :remove_entry_secure, :rm_rf

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -116,6 +116,12 @@ class FakeFSTest < Test::Unit::TestCase
     end
   end
 
+  def test_unlink_doesnt_error_on_file_not_found_with_rm_rf
+    assert_nothing_raised do
+      FileUtils.rm_rf("/foo")
+    end
+  end
+
   def test_can_delete_directories
     FileUtils.mkdir_p("/path/to/dir")
     FileUtils.rmdir("/path/to/dir")
@@ -135,7 +141,6 @@ class FakeFSTest < Test::Unit::TestCase
     assert FileUtils.respond_to?(:rm_f)
     assert FileUtils.respond_to?(:rm_r)
     assert FileUtils.respond_to?(:rm)
-    assert FileUtils.respond_to?(:rm_rf)
     assert FileUtils.respond_to?(:symlink)
     assert FileUtils.respond_to?(:move)
     assert FileUtils.respond_to?(:copy)


### PR DESCRIPTION
- FileUtils.mkdir_p accepts now the mode parameter and sets this for all parent directories.
- FileUtils.rm_rf is implemented as an alias to FileUtils.rm. This is wrong because then an exception is raised when any of the deleted directories doesn't exist.
