### PR TITLE
Fix chop_basename

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -587,13 +587,13 @@ module FakeFS
         base_directory = base_directory.cleanpath.to_s
         dest_prefix = dest_directory
         dest_names = []
-        while (r = chop_basename(dest_prefix)) == true
+        while (r = chop_basename(dest_prefix))
           dest_prefix, basename = r
           dest_names.unshift basename if basename != '.'
         end
         base_prefix = base_directory
         base_names = []
-        while (r = chop_basename(base_prefix)) == true
+        while (r = chop_basename(base_prefix))
           base_prefix, basename = r
           base_names.unshift basename if basename != '.'
         end


### PR DESCRIPTION
From the post of borodean: https://github.com/defunkt/fakefs/commit/a548517ad11a6c50653ce503954b73921c2a7597#commitcomment-7998206

chop_basename never returns a boolean

Sorry, my bad
