### PR TITLE
Remove methods before re-defining them

### DIFF
--- a/lib/fakefs/kernel.rb
+++ b/lib/fakefs/kernel.rb
@@ -9,12 +9,14 @@ module FakeFS
 
     def self.hijack!
       captives[:hijacked].each do |name, prc|
+        ::Kernel.send(:remove_method, name.to_sym)
         ::Kernel.send(:define_method, name.to_sym, &prc)
       end
     end
 
     def self.unhijack!
       captives[:original].each do |name, _prc|
+        ::Kernel.send(:remove_method, name.to_sym)
         ::Kernel.send(:define_method, name.to_sym, proc do |*args, &block|
           ::FakeFS::Kernel.captives[:original][name].call(*args, &block)
         end)


### PR DESCRIPTION
This prevents ruby from dumping a ton of "method redefined" warnings to the console.
