### PR TITLE
File.write accepts a fourth optional argument

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -517,14 +517,26 @@ module FakeFS
       def advise(_advice, _offset = 0, _len = 0)
       end
 
-      def self.write(filename, contents, offset = nil)
+      def self.write(filename, contents, offset = nil, open_args={})
+        offset, open_args = nil, offset if offset.kind_of?(Hash)
+        mode = offset ? 'a' : 'w'
+        if open_args.size > 0
+          if open_args[:open_args]
+            args = [ filename, *open_args[:open_args] ]
+          else
+            mode = open_args[:mode] || mode
+            args = [filename, mode , open_args]
+          end
+        else
+          args = [filename, mode]
+        end
         if offset
-          open(filename, 'a') do |f|
+          open(*args) do |f|
             f.seek(offset)
             f.write(contents)
           end
         else
-          open(filename, 'w') do |f|
+          open(*args) do |f|
             f << contents
           end
         end


### PR DESCRIPTION
Previous fake File.write did not accept the valid fourth argument
`open_args`.
This commit should provide a such possibility.
I do not certify correct behavior for all cases, but at least it won’t
raise a useless exception and will extends the fakers compatibility
