### PR TITLE
Remove unused attr_accessor :content

### DIFF
--- a/lib/fakefs/fake/file.rb
+++ b/lib/fakefs/fake/file.rb
@@ -1,7 +1,7 @@
 module FakeFS
   # Fake file class
   class FakeFile
-    attr_accessor :name, :parent, :content, :mtime, :atime, :mode, :uid, :gid
+    attr_accessor :name, :parent, :mtime, :atime, :mode, :uid, :gid
     attr_reader :ctime, :birthtime
 
     # Inode class


### PR DESCRIPTION
There are explicit `content` and `content=` methods defined within the `FakeFile` class. Retaining the `attr_accessor :content` declaration results in Ruby warnings for method redefinitions.

```
/../gems/fakefs-0.6.7/lib/fakefs/fake/file.rb:51: warning: method redefined; discarding old content
/../gems/fakefs-0.6.7/lib/fakefs/fake/file.rb:55: warning: method redefined; discarding old content=
```