### PR TITLE
Return entire path when globbing absolute path

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -98,6 +98,7 @@ module FakeFS
       matches_for_pattern = lambda do |matcher|
         [FileSystem.find(matcher) || []].flatten.map do |e|
           if Dir.pwd.match(/\A\/?\z/) ||
+             matcher.start_with?('/') ||
              !e.to_s.match(/\A#{Dir.pwd}\/?/)
             e.to_s
           else

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1137,6 +1137,14 @@ class FakeFSTest < Minitest::Test
     assert_equal ['/tmp/python-2.7.8', '/tmp/python-3.4.1'], Dir.glob('/tmp/python-[0-9]*')
   end
 
+  def test_dir_glob_absolute_path_after_chdir
+    FileUtils.mkdir_p '/foo/one'
+    FileUtils.mkdir_p '/foo/two'
+    assert_equal ['/foo/one', '/foo/two'], Dir.glob('/foo/*')
+    Dir.chdir('foo')
+    assert_equal ['/foo/one', '/foo/two'], Dir.glob('/foo/*')
+  end
+
   def test_dir_glob_with_block
     FileUtils.touch('foo')
     FileUtils.touch('bar')


### PR DESCRIPTION
When globbing for an absolute path from the root folder, absolute paths are returned. But when `chdir`'ing to a subfolder and globbing the same absolute path, only the relative paths were returned. `RealDir` would still return absolute paths in this case.
