### PR TITLE
Fix implementation of FakeFS::Pathname#unlink.

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -1009,8 +1009,11 @@ module FakeFS
       # Removes a file or directory, using <tt>File.unlink</tt> or
       # <tt>Dir.unlink</tt> as necessary.
       def unlink
-        Dir.unlink @path if File.directory? @path
-        File.unlink @path unless File.directory? @path
+        if File.directory? @path
+          Dir.unlink @path
+        else
+          File.unlink @path
+        end
       end
 
       alias_method :delete, :unlink

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -72,4 +72,18 @@ class FakePathnameTest < Minitest::Test
   def test_io_sysopen_is_unsupported
     assert_raises(NotImplementedError) { @pathname.sysopen }
   end
+
+  def test_files_are_unlinked
+    File.write(@path, '')
+
+    @pathname.unlink
+    refute @pathname.exist?
+  end
+
+  def test_directories_are_unlinked
+    Dir.mkdir(@path)
+
+    @pathname.unlink
+    refute @pathname.exist?
+  end
 end


### PR DESCRIPTION
I was experiencing problems when attempting to unlink a mocked directory using `Pathname`. The problem appears to be that after `Dir::unlink` is executed, the subsequent call to `File::directory?` (line 1013) evaluates to `false` incorrectly triggering `File::unlink` too.