### PR TITLE
Fix FakeFS::Pathname#root?, fixes #299

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -327,7 +327,7 @@ module FakeFS
       # pathnames which points to roots such as <tt>/usr/..</tt>.
       #
       def root?
-        !(chop_basename(@path).nil? && /#{SEPARATOR_PAT}/o =~ @path).nil?
+        chop_basename(@path).nil? && /#{SEPARATOR_PAT}/o =~ @path
       end
 
       # Predicate method for testing whether a path is absolute.

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -8,7 +8,7 @@ class FakePathnameTest < Minitest::Test
     FakeFS.activate!
     FileSystem.clear
 
-    @path = 'foo'
+    @path = '/foo'
     @pathname = Pathname.new(@path)
   end
 
@@ -22,6 +22,12 @@ class FakePathnameTest < Minitest::Test
     File.write(@path, '')
 
     assert @pathname.exist?
+  end
+
+  def test_root_check_returns_correct_value
+    refute @pathname.root?
+    root_path = Pathname.new('/')
+    assert root_path.root?
   end
 
   def test_io_each_line_with_block_yields_lines


### PR DESCRIPTION
`FakeFS::Pathname#root?` was broken by a548517. This commit adds a test and restores the old behaviour while keeping rubocop happy.