### PR TITLE
Raise ENOENT in FileUtils::cp_r, fixes #293

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -136,12 +136,18 @@ module FakeFS
       return if options[:noop]
 
       Array(src).each do |source|
-        # This error sucks, but it conforms to the original Ruby
-        # method.
-        fail "unknown file type: #{source}" unless
-          (dir = FileSystem.find(source))
-        new_dir = FileSystem.find(dest)
+        dir = FileSystem.find(source)
+        unless dir
+          if RUBY_VERSION >= '1.9.1'
+            fail Errno::ENOENT, source
+          else
+            # This error sucks, but it conforms to the original Ruby
+            # method.
+            fail "unknown file type: #{source}"
+          end
+        end
 
+        new_dir = FileSystem.find(dest)
         fail Errno::EEXIST, dest if new_dir && !File.directory?(dest)
         fail Errno::ENOENT, dest if !new_dir && !FileSystem.find(dest + '/../')
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1577,9 +1577,8 @@ class FakeFSTest < Minitest::Test
   end
 
   def test_cp_r_should_raise_error_on_missing_file
-    # Yes, this error sucks, but it conforms to the original Ruby
-    # method.
-    assert_raises(RuntimeError) do
+    exception = RUBY_VERSION >= '1.9.1' ? Errno::ENOENT : RuntimeError
+    assert_raises(exception) do
       FileUtils.cp_r 'blafgag', 'foo'
     end
   end


### PR DESCRIPTION
This pull request makes `FileUtils::cp_r` raise `Errno::ENOENT` instead of `RuntimeError` if the source directory does not exist.

Since Ruby 1.8 raises a `RuntimeError` in this situation, I added a version check to keep the current behaviour for Ruby <1.9.1. If you would rather omit the version check and just ignore Ruby 1.8 in this case, just let me know and I'll amend the pull request accordingly.