### PR TITLE
File methods should handle Pathname objects.

### DIFF
--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -167,6 +167,17 @@ class FakeFSTest < Minitest::Test
     assert File.exist?(path)
   end
 
+  def test_handles_pathnames
+    path = '/path/to/dir'
+    FileUtils.mkdir_p(path)
+
+    path_name = RealPathname.new(path)
+    assert File.directory?(path_name)
+
+    path_name = Pathname.new(path)
+    assert File.directory?(path_name)
+  end
+
   def test_knows_directories_are_directories
     FileUtils.mkdir_p(path = '/path/to/dir')
     assert File.directory?(path)


### PR DESCRIPTION
This is failing with:
```
  1) Error:
FakeFSTest#test_handles_pathnames:
NoMethodError: undefined method `[]' for #<Pathname:/path/to/dir>
    fakefs/lib/fakefs/globber.rb:7:in `expand'
    fakefs/lib/fakefs/file_system.rb:27:in `find'
    fakefs/lib/fakefs/file.rb:117:in `directory?'
    fakefs/test/fakefs_test.rb:175:in `test_handles_pathnames'
```

This tests passes on commit 4cce640fb131161afd2e22b76ba5498734e116f2. I think the break was introduced by #298.