### PR TITLE
Modified FakeFS::Globber methods to accept Pathname objects

### DIFF
--- a/lib/fakefs/globber.rb
+++ b/lib/fakefs/globber.rb
@@ -4,6 +4,8 @@ module FakeFS
     extend self
 
     def expand(pattern)
+      pattern = pattern.to_s
+
       return [pattern] if pattern[0] != '{' || pattern[-1] != '}'
 
       part = ''
@@ -39,6 +41,8 @@ module FakeFS
     end
 
     def path_components(pattern)
+      pattern = pattern.to_s
+
       part = ''
       result = []
 
@@ -57,6 +61,8 @@ module FakeFS
     end
 
     def regexp(pattern)
+      pattern = pattern.to_s
+
       regex_body = pattern.gsub('.', '\.')
                    .gsub('?', '.')
                    .gsub('*', '.*')

--- a/test/globber_test.rb
+++ b/test/globber_test.rb
@@ -25,4 +25,20 @@ class GlobberTest < Minitest::Test
   def test_path_components_with_path_separator_inside_brace_group
     assert_equal ['a', '{b,c/d}', 'e'], FakeFS::Globber.path_components('/a/{b,c/d}/e')
   end
+
+  def test_expand_accepts_pathname
+    assert_equal ['/a/b/c'], FakeFS::Globber.expand(Pathname.new('/a/b/c'))
+  end
+
+  def test_path_components_accepts_pathname
+    assert_equal %w(a b c), FakeFS::Globber.path_components(Pathname.new('/a/b/c'))
+  end
+
+  def test_regexp_accepts_string
+    assert_equal(%r{\A\/a\/b\/c\Z}.to_s, (FakeFS::Globber.regexp('/a/b/c')).to_s)
+  end
+
+  def test_regexp_accepts_pathname
+    assert_equal(%r{\A\/a\/b\/c\Z}.to_s, (FakeFS::Globber.regexp(Pathname.new('/a/b/c'))).to_s)
+  end
 end


### PR DESCRIPTION
I believe this pull request should address https://github.com/defunkt/fakefs/issues/326.  I decided not to do full integration testing for accepting `Pathname` objects, but instead simply to focus on validating that `FakeFS::Globber` would behave correctly.