### PR TITLE
Fix issue with Globber#regexp and the new Rails 4.2.5.1 glob pattern

### DIFF
--- a/lib/fakefs/globber.rb
+++ b/lib/fakefs/globber.rb
@@ -58,14 +58,20 @@ module FakeFS
 
     def regexp(pattern)
       regex_body = pattern.gsub('.', '\.')
+                   .gsub('+') { '\+' }
                    .gsub('?', '.')
                    .gsub('*', '.*')
                    .gsub('(', '\(')
                    .gsub(')', '\)')
-                   .gsub(/\{(.*?)\}/) do
-                     "(#{Regexp.last_match[1].gsub(',', '|')})"
-                   end
-                   .gsub(/\A\./, '(?!\.).')
+
+      loop do
+        break unless regex_body.gsub!(/(?<re>\{(?:(?>[^{}]+)|\g<re>)*\})/) do
+          "(#{Regexp.last_match[1][1..-2].gsub(',', '|')})"
+        end
+      end
+
+      regex_body = regex_body.gsub(/\A\./, '(?!\.).')
+
       /\A#{regex_body}\Z/
     end
 

--- a/test/globber_test.rb
+++ b/test/globber_test.rb
@@ -25,4 +25,8 @@ class GlobberTest < Minitest::Test
   def test_path_components_with_path_separator_inside_brace_group
     assert_equal ['a', '{b,c/d}', 'e'], FakeFS::Globber.path_components('/a/{b,c/d}/e')
   end
+
+  def test_regexp_accepts_nested_brace_groups_with_plus
+    assert_equal(/\Aa(\.(b)|)(\.(c)|)(\+()|)(\.(d|e|f)|)\Z/.to_s, (FakeFS::Globber.regexp('a{.{b},}{.{c},}{+{},}{.{d,e,f},}')).to_s)
+  end
 end


### PR DESCRIPTION
This should fix the issue in Globber#regexp with the new Rails 4.2.5.1 glob pattern - see https://github.com/defunkt/fakefs/issues/328.