### PR TITLE
Resolve issues with Pathname objects, Globber#regexp and the new Rails 4.2.5.1 glob pattern

### DIFF
--- a/lib/fakefs/globber.rb
+++ b/lib/fakefs/globber.rb
@@ -4,6 +4,8 @@ module FakeFS
     extend self
 
     def expand(pattern)
+      pattern = pattern.to_s
+
       return [pattern] if pattern[0] != '{' || pattern[-1] != '}'
 
       part = ''
@@ -39,6 +41,8 @@ module FakeFS
     end
 
     def path_components(pattern)
+      pattern = pattern.to_s
+
       part = ''
       result = []
 
@@ -57,6 +61,8 @@ module FakeFS
     end
 
     def regexp(pattern)
+      pattern = pattern.to_s
+
       regex_body = pattern.gsub('.', '\.')
                    .gsub('?', '.')
                    .gsub('*', '.*')

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -167,6 +167,17 @@ class FakeFSTest < Minitest::Test
     assert File.exist?(path)
   end
 
+  def test_handles_pathnames
+    path = '/path/to/dir'
+    FileUtils.mkdir_p(path)
+
+    path_name = RealPathname.new(path)
+    assert File.directory?(path_name)
+
+    path_name = Pathname.new(path)
+    assert File.directory?(path_name)
+  end
+
   def test_knows_directories_are_directories
     FileUtils.mkdir_p(path = '/path/to/dir')
     assert File.directory?(path)

--- a/test/globber_test.rb
+++ b/test/globber_test.rb
@@ -35,10 +35,14 @@ class GlobberTest < Minitest::Test
   end
 
   def test_regexp_accepts_string
-    assert_equal(%r{\A\/a\/b\/c\Z}.to_s, (FakeFS::Globber.regexp('/a/b/c')).to_s)
+    assert_equal(%r{\A/a/b/c\Z}.to_s, (FakeFS::Globber.regexp('/a/b/c')).to_s)
   end
 
   def test_regexp_accepts_pathname
-    assert_equal(%r{\A\/a\/b\/c\Z}.to_s, (FakeFS::Globber.regexp(Pathname.new('/a/b/c'))).to_s)
+    assert_equal(%r{\A/a/b/c\Z}.to_s, (FakeFS::Globber.regexp(Pathname.new('/a/b/c'))).to_s)
+  end
+
+  def test_regexp_accepts_nested_brace_groups_with_plus
+    assert_equal(/\Aa(\.(b)|)(\.(c)|)(\+()|)(\.(d|e|f)|)\Z/.to_s, (FakeFS::Globber.regexp('a{.{b},}{.{c},}{+{},}{.{d,e,f},}')).to_s)
   end
 end

--- a/test/globber_test.rb
+++ b/test/globber_test.rb
@@ -25,4 +25,20 @@ class GlobberTest < Minitest::Test
   def test_path_components_with_path_separator_inside_brace_group
     assert_equal ['a', '{b,c/d}', 'e'], FakeFS::Globber.path_components('/a/{b,c/d}/e')
   end
+
+  def test_expand_accepts_pathname
+    assert_equal ['/a/b/c'], FakeFS::Globber.expand(Pathname.new('/a/b/c'))
+  end
+
+  def test_path_components_accepts_pathname
+    assert_equal %w(a b c), FakeFS::Globber.path_components(Pathname.new('/a/b/c'))
+  end
+
+  def test_regexp_accepts_string
+    assert_equal(%r{\A\/a\/b\/c\Z}.to_s, (FakeFS::Globber.regexp('/a/b/c')).to_s)
+  end
+
+  def test_regexp_accepts_pathname
+    assert_equal(%r{\A\/a\/b\/c\Z}.to_s, (FakeFS::Globber.regexp(Pathname.new('/a/b/c'))).to_s)
+  end
 end


### PR DESCRIPTION
This pull request supersedes https://github.com/fakefs/fakefs/pull/330 and is rebased against current master.