### PR TITLE
Corrects FileUtils behaviour

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -106,7 +106,6 @@ module FakeFS
         src_file = FileSystem.find(source)
 
         fail Errno::ENOENT, source unless src_file
-        fail Errno::EISDIR, source if File.directory? src_file
 
         if dst_file && File.directory?(dst_file)
           FileSystem.add(

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1598,12 +1598,10 @@ class FakeFSTest < Minitest::Test
     end
   end
 
-  def test_cp_fails_on_directory_copy
-    FileUtils.mkdir_p 'baz'
-
-    assert_raises Errno::EISDIR do
-      FileUtils.cp('baz', 'bar')
-    end
+  def test_file_utils_cp_allows_source_directories
+    Dir.mkdir 'foo'
+    FileUtils.cp 'foo', 'bar'
+    assert Dir.exist? 'bar'
   end
 
   def test_copy_file_works


### PR DESCRIPTION
Hi there! I've encountered a problem where using FileUtils in my code wasn't behaving in my tests. I'm trying to copy a directory with `FileUtils.cp` but I'm getting the error: `Errno::EISDIR: Is a directory`. I checked [the documentation](http://ruby-doc.org/stdlib-2.3.1/libdoc/fileutils/rdoc/FileUtils.html#method-c-cp) and FileUtils does support copying directories this way. This pull requests removes that failure.

Note: as a workaround, I'm able to use `FileUtils.cp_r`.