### PR TITLE
Dir.chdir should pass in path to block

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -90,7 +90,7 @@ module FakeFS
       fail Errno::ENOENT, dir unless new_dir
 
       dir_levels.push dir unless blk
-      blk.call if blk
+      blk.call(dir) if blk
     ensure
       dir_levels.pop if blk
     end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1408,6 +1408,19 @@ class FakeFSTest < Minitest::Test
     assert_equal ['foo'], Dir.glob('*')
   end
 
+  def test_chdir_with_a_block_passes_in_the_path
+    FileUtils.mkdir_p('/path')
+    Dir.chdir('/path') do |path|
+      assert_equal '/path', path
+    end
+
+    Dir.chdir('/path')
+    FileUtils.mkdir('subdir')
+    Dir.chdir('subdir') do |path|
+      assert_equal 'subdir', path
+    end
+  end
+
   def test_current_dir_reflected_by_pwd
     FileUtils.mkdir_p '/path'
     Dir.chdir('/path')


### PR DESCRIPTION
According to the [docs for `Dir.chdir`](https://ruby-doc.org/core-2.3.1/Dir.html), the method signature with optional block is:

> chdir( [ string] ) { | path | block } → anObject

With the explanation:

> If a block is given, it is passed the name of the new current directory, and the block is executed with that as the current directory.

This has been true since at least 1.9.3. However, the `FakeFS::FileSystem.chdir` method just calls the supplied block without passing in any arguments. This would result in an ArgumentError every time fakefs is used with code that depends on the path arg.