### PR TITLE
Travis: Use current JRuby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ rvm:
   - 2.3.1
   - jruby-1.7.26
   - jruby-9.1.6.0
-  - rbx-19mode
 matrix:
   allow_failures:
     - rvm: jruby-1.7.26
     - rvm: jruby-9.1.6.0
-    - rvm: rbx-19mode
 before_install:
   - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ rvm:
   - 2.1.1
   - 2.2.0
   - 2.3.1
-  - jruby
+  - jruby-1.7.26
+  - jruby-9.1.6.0
   - rbx-19mode
 matrix:
   allow_failures:
-    - rvm: jruby
+    - rvm: jruby-1.7.26
+    - rvm: jruby-9.1.6.0
     - rvm: rbx-19mode
 before_install:
   - gem --version


### PR DESCRIPTION
This PR adds JRuby 9.1.6.0, and updates the 1.7 series to its latest release.