### PR TITLE
Spec: exclude a few public methods on File for JRuby

### DIFF
--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1292,6 +1292,7 @@ class FakeFSTest < Minitest::Test
   ]
 
   (RealFile.instance_methods - OMITTED_FILE_METHODS).each do |method_name|
+    next if defined?(JRUBY_VERSION) && [:ttymode, :ttymode_yield, :to_channel, :to_outputstream, :to_inputstream].include?(method_name)
     define_method("test_#{method_name}_method_in_file_is_in_fake_fs_file") do
       assert File.instance_methods.include?(method_name), "#{method_name} method is not available in File :("
     end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1267,7 +1267,7 @@ class FakeFSTest < Minitest::Test
     assert_equal 1, fp.pos
   end
 
-  OMITTED_FILE_METHODS = [
+  OMITTED_MRI_FILE_METHODS = [
     # omit methods from etc
     :pathconf,
 
@@ -1291,8 +1291,26 @@ class FakeFSTest < Minitest::Test
     :wait, :wait_readable, :wait_writable
   ]
 
-  (RealFile.instance_methods - OMITTED_FILE_METHODS).each do |method_name|
-    next if defined?(JRUBY_VERSION) && [:ttymode, :ttymode_yield, :to_channel, :to_outputstream, :to_inputstream].include?(method_name)
+  OMITTED_JRUBY_FILE_METHODS = [
+    # omit public methods re https://github.com/jruby/jruby/issues/4275
+    :ttymode,
+    :ttymode_yield,
+
+    # omit Java-oriented conversion methods
+    :to_channel,
+    :to_outputstream,
+    :to_inputstream
+  ]
+
+  def self.omitted_file_methods
+    if defined?(JRUBY_VERSION)
+      OMITTED_MRI_FILE_METHODS + OMITTED_JRUBY_FILE_METHODS
+    else
+      OMITTED_MRI_FILE_METHODS
+    end
+  end
+
+  (RealFile.instance_methods - omitted_file_methods).each do |method_name|
     define_method("test_#{method_name}_method_in_file_is_in_fake_fs_file") do
       assert File.instance_methods.include?(method_name), "#{method_name} method is not available in File :("
     end


### PR DESCRIPTION
FakeFS currently fails its "public method assertions on File" assertions for JRuby.

- This PR excludes the first two as known-to-be-public-but-perhaps-shouldn't. See https://github.com/jruby/jruby/issues/4275
- The `to_*` conversion methods need to be there. So they're also skipped, for JRuby

This makes the tests pass on JRuby 9.1.6.0.