### PR TITLE
Fix symlink rename

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -209,7 +209,12 @@ module FakeFS
       end
 
       if (target = FileSystem.find(source))
-        FileSystem.add(dest, target.entry.clone)
+        if target.is_a?(FakeFS::FakeSymlink)
+          File.symlink(target.target, dest)
+        else
+          FileSystem.add(dest, target.entry.clone)
+        end
+
         FileSystem.delete(source)
       else
         fail Errno::ENOENT, "#{source} or #{dest}"

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2266,6 +2266,15 @@ class FakeFSTest < Minitest::Test
     assert File.file?('/bar')
   end
 
+  def test_rename_renames_a_symlink
+    FileUtils.touch('/file')
+    File.symlink('/file', '/symlink')
+    assert_equal File.readlink('/symlink'), '/file'
+
+    File.rename('/symlink', '/symlink2')
+    assert_equal File.readlink('/symlink2'), '/file'
+  end
+
   def test_rename_returns
     FileUtils.touch('/foo')
     assert_equal 0, File.rename('/foo', '/bar')


### PR DESCRIPTION
Allows symlink renames to work as expected. Fixes issue #358.