### PR TITLE
FileUtils.rm_f should not raise Errno:ENOENT when a file is not found

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -64,8 +64,11 @@ module FakeFS
       end
     end
     alias_method :rm_r, :rm
-    alias_method :rm_f, :rm
     alias_method :remove, :rm
+
+    def rm_f(list, options = {})
+      rm(list, options.merge(force: true))
+    end
 
     def rm_rf(list, options = {})
       rm_r(list, options.merge(force: true))

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -132,6 +132,10 @@ class FakeFSTest < Minitest::Test
     FileUtils.rm_rf('/foo')
   end
 
+  def test_unlink_doesnt_error_on_file_not_found_with_rm_f
+    FileUtils.rm_f('/foo')
+  end
+
   def test_can_delete_directories
     FileUtils.mkdir_p('/path/to/dir')
     FileUtils.rmdir('/path/to/dir')


### PR DESCRIPTION
I'm relying on `FileUtils.rm_f` not minding if the file it's trying to delete is not there (because it's a concurrent environment, and another job may already have cleaned it up). The specs work fine with a real file system, but not with a FakeFS, unless I change the calls from `rm_f(myfile)` to `rm(myfile, force: true)`.

The [FileUtils docs)[http://apidock.com/ruby/FileUtils/rm_f] describe `rm_f` as:

>Equivalent to `#rm(list, :force => true)`