### PR TITLE
Fix rm_f when deleted dirs does not exist

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -64,14 +64,17 @@ module FakeFS
       end
     end
     alias_method :rm_r, :rm
-    alias_method :rm_f, :rm
     alias_method :remove, :rm
+
+    def rm_f(list, options = {})
+      rm(list, options.merge(force: true))
+    end
+    alias_method :safe_unlink, :rm_f
 
     def rm_rf(list, options = {})
       rm_r(list, options.merge(force: true))
     end
     alias_method :rmtree, :rm_rf
-    alias_method :safe_unlink, :rm_f
     alias_method :remove_entry_secure, :rm_rf
 
     def ln_s(target, path, options = {})

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -128,6 +128,10 @@ class FakeFSTest < Minitest::Test
     FileUtils.rm('/foo', force: true)
   end
 
+  def test_unlink_doesnt_error_on_file_not_found_with_rm_f
+    FileUtils.rm_f('/foo')
+  end
+
   def test_unlink_doesnt_error_on_file_not_found_with_rm_rf
     FileUtils.rm_rf('/foo')
   end
@@ -146,9 +150,16 @@ class FakeFSTest < Minitest::Test
     assert File.exist?('bar') == false
   end
 
+  def test_can_force_delete_multiple_files
+    FileUtils.touch(%w(foo bar))
+    FileUtils.rm_f(%w(foo missing bar))
+    assert File.exist?('foo')     == false
+    assert File.exist?('missing') == false
+    assert File.exist?('bar')     == false
+  end
+
   def test_aliases_exist
     assert File.respond_to?(:unlink)
-    assert FileUtils.respond_to?(:rm_f)
     assert FileUtils.respond_to?(:rm_r)
     assert FileUtils.respond_to?(:rm)
     assert FileUtils.respond_to?(:symlink)


### PR DESCRIPTION
FileUtils.rm_f was implemented as an alias to FileUtils.rm.
This is wrong because an exception is raise if the file does not exist.

This change is similar to an earlier commit to fix the same problem with
FileUtils.rm_rf. (i.e., commit  ab3b1d1e75973f2faadd9d52b3111e6fa1e82c06)