### PR TITLE
So fresh and so clean

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,3 +101,4 @@ Benjamin Fleischer <github@benjaminfleischer.com>
 Jordi Massaguer Pla <jmassaguerpla@suse.de>
 Maria Shaldibina <mariash@pivotallabs.com>
 Vít Ondruch <vondruch@redhat.com>
+Ian Katz <ifreecarve@gmail.com>

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ end
 
 See `lib/fakefs/spec_helpers.rb` for more info.
 
+To use FakeFS within a single test and be guaranteed a fresh fake filesystem:
+``` ruby
+require 'fakefs/safe'
+
+describe "my spec" do
+  context "my context" do
+    it "does something to the filesystem"
+      FakeFS.with_fresh do
+        # whatever it does
+      end
+    end
+  end
+end
+```
+
+
 FakeFs --- `TypeError: superclass mismatch for class File`
 --------------
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ is the only thing that is guaranteed to exist, namely the root (i.e. `/`). This
 may be important when upgrading from v0.4.x to v0.5.x, especially if you depend
 on the real working directory while using FakeFS.
 
+FakeFS replaces File and FileUtils, but is not a filesystem replacement, so gems
+that use strange commands or C might circumvent it.  For example, the `sqlite3`
+gem will completely ignore any faked filesystem.
 
 Speed?
 ------

--- a/README.md
+++ b/README.md
@@ -96,10 +96,19 @@ end
 
 See `lib/fakefs/spec_helpers.rb` for more info.
 
-FakeFs vs `pp` --- `TypeError: superclass mismatch for class File`
+FakeFs --- `TypeError: superclass mismatch for class File`
 --------------
 
-`pp` and `fakefs` collide, `require 'pp'` then `require 'fakefs'`.
+`pp` and `fakefs` may collide, even if you're not actually explicitly using `pp`.  Adding `require 'pp'` before `require 'fakefs'` should fix the problem locally.  For a module-level fix, try adding it to the `Gemfile`:
+
+```ruby
+source "https://rubygems.org"
+
+require 'pp'
+# list of gems
+```
+
+The problem may not be limited to `pp`; any gems that add to `File` may be affected.
 
 Working with existing files
 ---------------------------

--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -70,6 +70,12 @@ module FakeFS
       ::FakeFS::FileSystem.clear
     end
 
+    # present a fresh new fake filesystem to the block
+    def fresh(&block)
+      clear!
+      with(&block)
+    end
+
     # present the fake filesystem to the block
     def with
       if activated?

--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -71,7 +71,7 @@ module FakeFS
     end
 
     # present a fresh new fake filesystem to the block
-    def fresh(&block)
+    def with_fresh(&block)
       clear!
       with(&block)
     end

--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -65,6 +65,11 @@ module FakeFS
       true
     end
 
+    # unconditionally clear the fake filesystem
+    def clear!
+      ::FakeFS::FileSystem.clear
+    end
+
     # present the fake filesystem to the block
     def with
       if activated?

--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -21,6 +21,7 @@ module FakeFS
       @activated ? true : false
     end
 
+    # unconditionally activate
     def activate!
       Object.class_eval do
         remove_const(:Dir)
@@ -42,6 +43,7 @@ module FakeFS
       true
     end
 
+    # unconditionally deactivate
     def deactivate!
       Object.class_eval do
         remove_const(:Dir)
@@ -63,6 +65,7 @@ module FakeFS
       true
     end
 
+    # present the fake filesystem to the block
     def with
       if activated?
         yield
@@ -76,6 +79,7 @@ module FakeFS
       end
     end
 
+    # present a non-fake filesystem to the block
     def without
       if !activated?
         yield

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -981,7 +981,11 @@ class FakeFSTest < Minitest::Test
     bad = 'nofile.txt'
     File.open(good, 'w') { |f| f.write 'foo' }
     username = Etc.getpwuid(Process.uid).name
-    groupname = Etc.getgrgid(Process.gid).name
+    groupname = begin
+      Etc.getgrgid(Process.gid).name
+    rescue ArgumentError # probably OSX, fall back on GID
+      Process.gid
+    end
 
     out = FileUtils.chown(1337, 1338, good, verbose: true)
     assert_equal [good], out
@@ -1019,7 +1023,11 @@ class FakeFSTest < Minitest::Test
 
   def test_can_chown_R_files
     username = Etc.getpwuid(Process.uid).name
-    groupname = Etc.getgrgid(Process.gid).name
+    groupname = begin
+      Etc.getgrgid(Process.gid).name
+    rescue ArgumentError # probably OSX, fall back on GID
+      Process.gid
+    end
     FileUtils.mkdir_p '/path/'
     File.open('/path/foo', 'w') { |f| f.write 'foo' }
     File.open('/path/foobar', 'w') { |f| f.write 'foo' }

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -976,16 +976,18 @@ class FakeFSTest < Minitest::Test
     refute File.executable?('/does/not/exist')
   end
 
+  def groupname_of_id(gid)
+    Etc.getgrgid(gid).name
+  rescue ArgumentError # probably OSX, fall back on GID
+    gid
+  end
+
   def test_can_chown_files
     good = 'file.txt'
     bad = 'nofile.txt'
     File.open(good, 'w') { |f| f.write 'foo' }
     username = Etc.getpwuid(Process.uid).name
-    groupname = begin
-      Etc.getgrgid(Process.gid).name
-    rescue ArgumentError # probably OSX, fall back on GID
-      Process.gid
-    end
+    groupname = groupname_of_id(Process.gid)
 
     out = FileUtils.chown(1337, 1338, good, verbose: true)
     assert_equal [good], out
@@ -1023,11 +1025,7 @@ class FakeFSTest < Minitest::Test
 
   def test_can_chown_R_files
     username = Etc.getpwuid(Process.uid).name
-    groupname = begin
-      Etc.getgrgid(Process.gid).name
-    rescue ArgumentError # probably OSX, fall back on GID
-      Process.gid
-    end
+    groupname = groupname_of_id(Process.gid)
     FileUtils.mkdir_p '/path/'
     File.open('/path/foo', 'w') { |f| f.write 'foo' }
     File.open('/path/foobar', 'w') { |f| f.write 'foo' }

--- a/test/safe_test.rb
+++ b/test/safe_test.rb
@@ -55,7 +55,7 @@ class FakeFSSafeTest < Minitest::Test
 
     refute File.exist?(path)
 
-    FakeFS.fresh do
+    FakeFS.with_fresh do
       refute File.exist?(path)
     end
   end

--- a/test/safe_test.rb
+++ b/test/safe_test.rb
@@ -45,6 +45,23 @@ class FakeFSSafeTest < Minitest::Test
     end
   end
 
+  def test_FakeFS_clear_method_clears_fs
+    path = 'file.txt'
+
+    FakeFS do
+      File.open(path, 'w') { |f| f.write 'Yatta!' }
+      assert File.exist?(path)
+    end
+
+    refute File.exist?(path)
+
+    FakeFS.clear!
+
+    FakeFS do
+      refute File.exist?(path)
+    end
+  end
+
   def test_FakeFS_method_returns_value_of_yield
     result = FakeFS do
       File.open('myfile.txt', 'w') { |f| f.write 'Yatta!' }

--- a/test/safe_test.rb
+++ b/test/safe_test.rb
@@ -45,6 +45,21 @@ class FakeFSSafeTest < Minitest::Test
     end
   end
 
+  def test_FakeFS_fresh_method_presents_fresh_fs
+    path = 'file.txt'
+
+    FakeFS do
+      File.open(path, 'w') { |f| f.write 'Yatta!' }
+      assert File.exist?(path)
+    end
+
+    refute File.exist?(path)
+
+    FakeFS.fresh do
+      refute File.exist?(path)
+    end
+  end
+
   def test_FakeFS_clear_method_clears_fs
     path = 'file.txt'
 

--- a/test/safe_test.rb
+++ b/test/safe_test.rb
@@ -30,6 +30,21 @@ class FakeFSSafeTest < Minitest::Test
     refute File.exist?(path)
   end
 
+  def test_FakeFS_method_presents_persistent_fs
+    path = 'file.txt'
+
+    FakeFS do
+      File.open(path, 'w') { |f| f.write 'Yatta!' }
+      assert File.exist?(path)
+    end
+
+    refute File.exist?(path)
+
+    FakeFS do
+      assert File.exist?(path)
+    end
+  end
+
   def test_FakeFS_method_returns_value_of_yield
     result = FakeFS do
       File.open('myfile.txt', 'w') { |f| f.write 'Yatta!' }


### PR DESCRIPTION
* Fixes #364 
* Fixes #365 
*  Fixes `ArgumentError: can't find group` when running tests on OSX
* Surfaces `FileSystem.clear` within `FakeFS`
* Adds `FakeFS.fresh`, which ensures a blank-slate FS for each block (useful during unit tests)
* Explicitly add rubocop to CI