### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.0
   - 2.3.1
   - jruby-1.7.27
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
 env:
   matrix:
     - TASK=test
@@ -16,7 +16,7 @@ env:
 matrix:
   allow_failures:
     - rvm: jruby-1.7.27
-    - rvm: jruby-9.1.10.0
+    - rvm: jruby-9.1.12.0
 before_install:
   - gem --version
 script: bundle exec rake $TASK


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html