### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.3.1
   - 2.4.1
   - jruby-1.7.27
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
 env:
   matrix:
     - TASK=test
@@ -17,7 +17,7 @@ env:
 matrix:
   allow_failures:
     - rvm: jruby-1.7.27
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
 before_install:
   - gem --version
 script: bundle exec rake $TASK


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html