### PR TITLE
Travis: Prepare newer Bundler in before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ matrix:
     - rvm: jruby-9.1.13.0
 before_install:
   - gem --version
+  - gem install bundler
 script: bundle exec rake $TASK


### PR DESCRIPTION
This PR updates bundler in the `before_install` step.

The goal is to build green on all supported targets.