### PR TITLE
JRuby 9.2: Undefine and skip aliases to_output_stream, to_input_stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.4.1
   - jruby-1.7.27
   - jruby-9.1.13.0
+  - jruby-head
 env:
   matrix:
     - TASK=test
@@ -18,6 +19,7 @@ matrix:
   allow_failures:
     - rvm: jruby-1.7.27
     - rvm: jruby-9.1.13.0
+    - rvm: jruby-head
 before_install:
   - gem --version
   - gem install bundler

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -437,6 +437,9 @@ module FakeFS
       undef_method :to_channel
       undef_method :to_outputstream
       undef_method :to_inputstream
+      # JRuby 9.2.0.0
+      undef_method :to_output_stream if respond_to?(:to_output_stream)
+      undef_method :to_input_stream if respond_to?(:to_input_stream)
     end
 
     def is_a?(klass)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1318,9 +1318,18 @@ class FakeFSTest < Minitest::Test
     :to_inputstream
   ].freeze
 
+  OMITTED_JRUBY_92_FILE_METHODS = [
+    :to_output_stream,
+    :to_input_stream
+  ].freeze
+
   def self.omitted_file_methods
     if defined?(JRUBY_VERSION)
-      OMITTED_MRI_FILE_METHODS + OMITTED_JRUBY_FILE_METHODS
+      if JRUBY_VERSION < '9.2'
+        OMITTED_MRI_FILE_METHODS + OMITTED_JRUBY_FILE_METHODS
+      else
+        OMITTED_MRI_FILE_METHODS + OMITTED_JRUBY_FILE_METHODS + OMITTED_JRUBY_92_FILE_METHODS
+      end
     else
       OMITTED_MRI_FILE_METHODS
     end


### PR DESCRIPTION
This PR **adds more methods to be ignored** by the faking, because JRuby's master has included more of them.

In order to test it with JRuby's current VERSION, I added `jruby-head` to the CI matrix.

- Fixes #377 

