### PR TITLE
Fix symlink lookup in sub-directories

### DIFF
--- a/lib/fakefs/fake/symlink.rb
+++ b/lib/fakefs/fake/symlink.rb
@@ -12,7 +12,7 @@ module FakeFS
     end
 
     def entry
-      FileSystem.find(target)
+      FileSystem.find(File.expand_path(target.to_s, parent.to_s))
     end
 
     def delete

--- a/test/fake/file/stat_test.rb
+++ b/test/fake/file/stat_test.rb
@@ -37,4 +37,14 @@ class FakeFileStatTest < Minitest::Test
 
     assert_equal File.stat('my_symlink').size, File.stat('foo').size
   end
+
+  def test_stat_should_report_on_symlink_pointer_in_subdirectory
+    Dir.mkdir('tmp')
+    Dir.chdir('tmp') do
+      File.open('foo', 'w') { |f| f << 'some content' }
+      File.symlink 'foo', 'my_symlink'
+      assert_equal File.stat('my_symlink').size, File.stat('foo').size
+    end
+    assert_equal File.stat('tmp/my_symlink').size, File.stat('tmp/foo').size
+  end
 end


### PR DESCRIPTION
Hi, we noticed that symlink lookup doesn't work in subdirectories.
The fix seems rather simple unless we missed some intricacies.