### PR TITLE
Create a method for File.identical?

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -55,6 +55,10 @@ module FakeFS
       alias_method :readable?, :exist?
       alias_method :writable?, :exist?
 
+      def identical?(one_path, another_path)
+        FileSystem.find(one_path) == FileSystem.find(another_path)
+      end
+
       # Assume nothing is sticky.
       def sticky?(_path)
         false


### PR DESCRIPTION
The CarrierWave gem invokes File.identical?, resulting in this error in my tests:

```
NoMethodError:
       undefined method `identical?' for FakeFS::File:Class
```