### PR TITLE
Ruby 2.4 additions: File.empty?, Dir.empty?, Pathname#empty?

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -90,6 +90,17 @@ module FakeFS
       Dir.new(dirname).map { |file| File.basename(file) }
     end
 
+    if RUBY_VERSION >= '2.4'
+      def self.empty?(dirname)
+        _check_for_valid_file(dirname)
+        if File.directory?(dirname)
+          Dir.new(dirname).count <= 2
+        else
+          false
+        end
+      end
+    end
+
     def self.foreach(dirname, &_block)
       Dir.open(dirname) { |file| yield file }
     end

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -110,6 +110,12 @@ module FakeFS
       exists?(path) && size(path) == 0
     end
 
+    if RUBY_VERSION >= '2.4'
+      class << self
+        alias_method :empty?, :zero?
+      end
+    end
+
     def self.const_missing(name)
       RealFile.const_get(name)
     end

--- a/lib/fakefs/file_test.rb
+++ b/lib/fakefs/file_test.rb
@@ -33,7 +33,7 @@ module FakeFS
 
     if RUBY_VERSION > '2.4'
       class << self
-        alias :empty? :zero?
+        alias empty? zero?
       end
     end
   end

--- a/lib/fakefs/file_test.rb
+++ b/lib/fakefs/file_test.rb
@@ -26,5 +26,15 @@ module FakeFS
     def writable?(file_name)
       File.writable?(file_name)
     end
+
+    def zero?(file_name)
+      File.zero?(file_name)
+    end
+
+    if RUBY_VERSION > '2.4'
+      class << self
+        alias_method :empty?, :zero?
+      end
+    end
   end
 end

--- a/lib/fakefs/file_test.rb
+++ b/lib/fakefs/file_test.rb
@@ -33,7 +33,7 @@ module FakeFS
 
     if RUBY_VERSION > '2.4'
       class << self
-        alias_method :empty?, :zero?
+        alias :empty? :zero?
       end
     end
   end

--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -1019,6 +1019,18 @@ module FakeFS
       end
 
       alias_method :delete, :unlink
+
+      if RUBY_VERSION > '2.4'
+        # Checks if a file or directory is empty, using
+        # <tt>FileTest.empty?</tt> or <tt>Dir.empty?</tt> as necessary.
+        def empty?
+          if File.directory? @path
+            Dir.empty? @path
+          else
+            FileTest.empty? @path
+          end
+        end
+      end
     end
 
     # Pathname class

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1268,6 +1268,48 @@ class FakeFSTest < Minitest::Test
     end
   end
 
+  if RUBY_VERSION >= '2.4'
+    def test_dir_empty_on_empty_directory
+      dir_path = 'an-empty-dir'
+      FileUtils.mkdir dir_path
+
+      assert_equal true, Dir.empty?(dir_path)
+    end
+
+    def test_dir_empty_on_directory_with_subdirectory
+      parent  = 'parent'
+      child = 'child'
+      path = File.join(parent, child)
+      FileUtils.mkdir_p path
+
+      assert_equal false, Dir.empty?(parent)
+    end
+
+    def test_dir_empty_on_directory_with_file
+      dir_path = 'a-non-empty-dir'
+      FileUtils.mkdir dir_path
+      file_path = File.join(dir_path, 'file.txt')
+      FileUtils.touch(file_path)
+
+      assert_equal false, Dir.empty?(dir_path)
+    end
+
+    def test_dir_empty_on_nonexistent_path
+      assert_raises(Errno::ENOENT) { Dir.empty?('/not/a/real/dir/') }
+    end
+
+    def test_dir_empty_on_file
+      path = 'file.txt'
+      FileUtils.touch(path)
+
+      assert_equal false, Dir.empty?(path)
+    end
+  else
+    def test_dir_empty_not_implemented
+      assert_equal false, Dir.respond_to?(:empty?)
+    end
+  end
+
   def test_should_report_pos_as_0_when_opening
     File.open('foo', 'w') do |f|
       f << 'foobar'

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1277,7 +1277,7 @@ class FakeFSTest < Minitest::Test
     end
 
     def test_dir_empty_on_directory_with_subdirectory
-      parent  = 'parent'
+      parent = 'parent'
       child = 'child'
       path = File.join(parent, child)
       FileUtils.mkdir_p path
@@ -2674,7 +2674,7 @@ class FakeFSTest < Minitest::Test
     end
   else
     def test_filetest_empty_not_implemented
-      refute FileTest.respond_to?(:empty?)  
+      refute FileTest.respond_to?(:empty?)
     end
   end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -627,6 +627,33 @@ class FakeFSTest < Minitest::Test
     assert_equal false, File.zero?(path)
   end
 
+  if RUBY_VERSION >= '2.4'
+    def test_empty_on_empty_file
+      path = 'file.txt'
+      File.open(path, 'w') do |f|
+        f << ''
+      end
+      assert_equal true, File.empty?(path)
+    end
+
+    def test_empty_on_non_empty_file
+      path = 'file.txt'
+      File.open(path, 'w') do |f|
+        f << 'Not empty'
+      end
+      assert_equal false, File.empty?(path)
+    end
+
+    def test_empty_on_non_existent_file
+      path = 'file_does_not_exist.txt'
+      assert_equal false, File.empty?(path)
+    end
+  else
+    def test_file_empty_not_implemented
+      assert_equal false, File.respond_to?(:empty?)
+    end
+  end
+
   def test_raises_error_on_mtime_if_file_does_not_exist
     assert_raises Errno::ENOENT do
       File.mtime('/path/to/file.txt')

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2650,6 +2650,34 @@ class FakeFSTest < Minitest::Test
     assert FileTest.writable?('dir'), 'directories are writable'
   end
 
+  def test_filetest_zero_returns_correct_values
+    refute FileTest.zero?('/not/a/real/directory')
+
+    filepath = 'here.txt'
+    FileUtils.touch filepath
+    assert FileTest.zero?(filepath)
+
+    File.write(filepath, 'content')
+    refute FileTest.zero?(filepath)
+  end
+
+  if RUBY_VERSION > '2.4'
+    def test_filetest_empty_returns_correct_values
+      refute FileTest.empty?('/not/a/real/directory')
+
+      filepath = 'here.txt'
+      FileUtils.touch filepath
+      assert FileTest.empty?(filepath)
+
+      File.write(filepath, 'content')
+      refute FileTest.empty?(filepath)
+    end
+  else
+    def test_filetest_empty_not_implemented
+      refute FileTest.respond_to?(:empty?)  
+    end
+  end
+
   def test_dir_mktmpdir
     # FileUtils.mkdir '/tmpdir'
 

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -102,7 +102,7 @@ class PathnameTest < Minitest::Test
 
     def test_pathname_empty_on_non_empty_directory
       Dir.mkdir(@path)
-      file_path = File.join(@path, "a_file.txt")
+      file_path = File.join(@path, 'a_file.txt')
       FileUtils.touch(file_path)
 
       assert_equal false, @pathname.empty?

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -92,4 +92,42 @@ class PathnameTest < Minitest::Test
     @pathname.unlink
     refute @pathname.exist?
   end
+
+  if RUBY_VERSION > '2.4'
+    def test_pathname_empty_on_empty_directory
+      Dir.mkdir(@path)
+
+      assert_equal true, @pathname.empty?
+    end
+
+    def test_pathname_empty_on_non_empty_directory
+      Dir.mkdir(@path)
+      file_path = File.join(@path, "a_file.txt")
+      FileUtils.touch(file_path)
+
+      assert_equal false, @pathname.empty?
+    end
+
+    def test_pathname_empty_on_empty_file
+      File.write(@path, '')
+
+      assert_equal true, @pathname.empty?
+    end
+
+    def test_pathname_empty_on_non_empty_file
+      File.write(@path, "some\ncontent")
+
+      assert_equal false, @pathname.empty?
+    end
+
+    def test_pathname_empty_on_nonexistent_path
+      refute @pathname.exist?
+
+      assert_equal false, @pathname.empty?
+    end
+  else
+    def test_pathname_empty_not_implemented
+      assert_equal false, Pathname.instance_methods.include?(:empty?)
+    end
+  end
 end


### PR DESCRIPTION
The [release of Ruby 2.4.0](https://github.com/ruby/ruby/blob/v2_4_0/NEWS) included the addition of these methods:

* `File.empty?` [(Ruby issue)](https://bugs.ruby-lang.org/issues/9969)
* `Dir.empty?` [(Ruby issue)](https://bugs.ruby-lang.org/issues/10121)
* `Pathname#empty?`[(Ruby issue)](https://bugs.ruby-lang.org/issues/12596)

This pull request implements those methods in Ruby >=2.4. It also includes `FileTest.empty?` (Ruby >=2.4) and `FileTest.zero?` (any Ruby), which are used by `Pathname#empty?`.

Please feel free to let me know if there are things I could change to get this approved. I recently dealt with a fun bug after a Ruby upgrade because ActiveSupport's addition of `Object#blank?` determines its behavior based on if objects respond to `empty?`.