### PR TITLE
Add ruby 2.5.0 children and each_child methods support

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -90,6 +90,17 @@ module FakeFS
       Dir.new(dirname).map { |file| File.basename(file) }
     end
 
+    def self.children(dirname, opts = {})
+      entries(dirname, opts) - %w(. ..)
+    end
+
+    def self.each_child(dirname, &_block)
+      Dir.open(dirname) do |file|
+        next if %w(. ..).include?(file)
+        yield file
+      end
+    end
+
     if RUBY_VERSION >= '2.4'
       def self.empty?(dirname)
         _check_for_valid_file(dirname)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2205,6 +2205,21 @@ class FakeFSTest < Minitest::Test
     test.each { |t| assert yielded.include?(t) }
   end
 
+  def test_directory_children
+    test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5']
+    test_with_files_only = test - %w(. ..)
+
+    FileUtils.mkdir_p('/this/path/should/be/here')
+
+    test.each do |f|
+      FileUtils.touch("/this/path/should/be/here/#{f}")
+    end
+
+    yielded = Dir.children('/this/path/should/be/here')
+    assert yielded.size == test_with_files_only.size
+    test_with_files_only.each { |t| assert yielded.include?(t) }
+  end
+
   def test_directory_entries_works_with_trailing_slash
     test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5']
 
@@ -2226,6 +2241,25 @@ class FakeFSTest < Minitest::Test
   end
 
   def test_directory_foreach
+    test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5']
+    test_with_files_only = test - %w(. ..)
+
+    FileUtils.mkdir_p('/this/path/should/be/here')
+
+    test.each do |f|
+      FileUtils.touch("/this/path/should/be/here/#{f}")
+    end
+
+    yielded = []
+    Dir.each_child('/this/path/should/be/here') do |dir|
+      yielded << dir
+    end
+
+    assert yielded.size == test_with_files_only.size
+    test_with_files_only.each { |t| assert yielded.include?(t) }
+  end
+
+  def test_directory_each_child
     test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5']
 
     FileUtils.mkdir_p('/this/path/should/be/here')


### PR DESCRIPTION
Ruby 2.5.0 resently introduced new methods Dir.children and Dir.each_child to use them when we want to have access only to the children files and directories.