### PR TITLE
Add support for Pathname#/

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -432,6 +432,7 @@ module FakeFS
         other = Pathname.new(other) unless other.is_a?(Pathname)
         Pathname.new(plus(@path, other.to_s))
       end
+      alias_method :/, :+
 
       def plus(path1, path2) # -> path
         prefix2 = path2

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -99,6 +99,12 @@ class PathnameTest < Minitest::Test
     assert_equal "some\ncontent", @pathname.read
   end
 
+  if RUBY_VERSION >= '2.2'
+    def test_pathname_slash
+      assert_equal Pathname.new('foo') / 'bar', Pathname.new('foo/bar')
+    end
+  end
+
   if RUBY_VERSION > '2.4'
     def test_pathname_empty_on_empty_directory
       Dir.mkdir(@path)


### PR DESCRIPTION
This method was added to Pathname in ruby 2.2. It was missing
from FakeFS.

This commit adds a test for the behavior that runs on rubies
2.2 and greater, and adds the alias to :+ to all versions,
fixing the bug.