### PR TITLE
Fix broken error message in FileUtils.cp when passing a Pathname

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -108,7 +108,7 @@ module FakeFS
         dst_file = FileSystem.find(dest)
         src_file = FileSystem.find(source)
 
-        fail Errno::ENOENT, source unless src_file
+        fail Errno::ENOENT, source.to_s unless src_file
 
         if dst_file && File.directory?(dst_file)
           FileSystem.add(

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -182,6 +182,12 @@ class FakeFSTest < Minitest::Test
     assert File.directory?(path_name)
   end
 
+  def test_throws_a_correct_error_with_missing_pathname
+    assert_raises Errno::ENOENT do
+      FileUtils.cp(Pathname.new("one"), Pathname.new("two"))
+    end
+  end
+
   def test_knows_directories_are_directories
     FileUtils.mkdir_p(path = '/path/to/dir')
     assert File.directory?(path)


### PR DESCRIPTION
Resolves at least part of #391 