### PR TITLE
Travis: use JRuby 9.1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - jruby-1.7.27
-  - jruby-9.1.13.0
+  - jruby-9.1.17.0
   - jruby-head
 env:
   matrix:
@@ -14,7 +14,7 @@ env:
 matrix:
   allow_failures:
     - rvm: jruby-1.7.27
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.17.0
     - rvm: jruby-head
   include:
     - rvm: 2.3.7 # lowest from rvm list above


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/04/23/jruby-9-1-17-0.html