### PR TITLE
Support calling File.size() on a directory

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -101,7 +101,11 @@ module FakeFS
     end
 
     def self.size(path)
-      read(path).bytesize
+      if directory?(path)
+        64 + (32 * FileSystem.find(path).entries.size)
+      else
+        read(path).bytesize
+      end
     end
 
     def self.size?(path)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -588,6 +588,28 @@ class FakeFSTest < Minitest::Test
     assert_equal 5, File.size(path)
   end
 
+  def test_can_get_correct_size_for_empty_directory
+    Dir.mkdir '/foo'
+    assert_equal 64, File.size?('/foo')
+  end
+
+  def test_can_get_correct_size_for_parent_directory
+    FileUtils.mkdir_p '/foo/bar'
+    assert_equal 96, File.size?('/foo')
+  end
+
+  def test_can_get_correct_size_for_grandparent_directory
+    FileUtils.mkdir_p '/foo/bar/baz'
+    assert_equal 96, File.size?('/foo')
+  end
+
+  def test_can_get_correct_size_for_grandparent_directory_with_files
+    FileUtils.mkdir_p '/foo/bar/baz'
+    File.open('/foo/a.txt', 'w')
+    File.open('/foo/bar/b.txt', 'w')
+    assert_equal 128, File.size?('/foo')
+  end
+
   def test_can_check_if_file_has_size?
     path = 'file.txt'
     File.open(path, 'w') do |f|
@@ -603,6 +625,11 @@ class FakeFSTest < Minitest::Test
       f << ''
     end
     assert_nil File.size?('file.txt')
+  end
+
+  def test_can_check_size_of_directory
+    Dir.mkdir '/foo'
+    assert_equal 64, File.size?('/foo')
   end
 
   def test_zero_on_empty_file


### PR DESCRIPTION
Fixes #405 

Ruby supports passing a directory to `File.size`, so should fakefs
Size calculation seems consistent with observations of running `File.size` on a Mac