### PR TITLE
unalias remove_entry_secure and implement proper call to rm_rf

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -74,7 +74,10 @@ module FakeFS
     end
     alias rmtree rm_rf
     alias safe_unlink rm_f
-    alias remove_entry_secure rm_rf
+
+    def remove_entry_secure(path, force = false)
+      rm_rf(path, force: force)
+    end
 
     def ln_s(target, path, options = {})
       options = { force: false }.merge(options)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -160,7 +160,6 @@ class FakeFSTest < Minitest::Test
     assert FileUtils.respond_to?(:remove)
     assert FileUtils.respond_to?(:rmtree)
     assert FileUtils.respond_to?(:safe_unlink)
-    assert FileUtils.respond_to?(:remove_entry_secure)
     assert FileUtils.respond_to?(:cmp)
     assert FileUtils.respond_to?(:identical?)
   end
@@ -3075,5 +3074,15 @@ class FakeFSTest < Minitest::Test
   def test_file_birthtime_is_equal_to_file_stat_birthtime
     File.open('foo', 'w') { |f| f << 'some content' }
     assert_equal File.stat('foo').birthtime, File.birthtime('foo')
+  end
+
+  def test_remove_entry_secure_removes_files
+    File.open('foo', 'w') { |f| f << 'some content' }
+    FileUtils.remove_entry_secure('foo', false)
+    assert File.exist?('foo') == false
+
+    File.open('foo', 'w') { |f| f << 'some content' }
+    FileUtils.remove_entry_secure('foo', true)
+    assert File.exist?('foo') == false
   end
 end


### PR DESCRIPTION
Change `remove_entry_secure` from alias of `rm_rf` to a call of `rm_rf` with proper arguments to remedy issue noted in https://github.com/fakefs/fakefs/issues/396.