### PR TITLE
Allow fakefs to handle files with braces in name.

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -119,7 +119,7 @@ module FakeFS
 
     def self.glob(pattern, flags = 0, &block)
       matches_for_pattern = lambda do |matcher|
-        [FileSystem.find(matcher, flags) || []].flatten.map do |e|
+        [FileSystem.find(matcher, flags, true) || []].flatten.map do |e|
           if Dir.pwd.match(%r{\A/?\z}) ||
              !e.to_s.match(%r{\A#{Dir.pwd}/?})
             e.to_s

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -20,13 +20,13 @@ module FakeFS
       fs.entries
     end
 
-    def find(path, find_flags = 0)
+    def find(path, find_flags = 0, gave_char_class = false)
       parts = path_parts(normalize_path(path))
       return fs if parts.empty? # '/'
 
       entries = Globber.expand(path).flat_map do |pattern|
         parts = path_parts(normalize_path(pattern))
-        find_recurser(fs, parts, find_flags).flatten
+        find_recurser(fs, parts, find_flags, gave_char_class).flatten
       end
 
       case entries.length
@@ -116,7 +116,7 @@ module FakeFS
 
     private
 
-    def find_recurser(dir, parts, find_flags = 0)
+    def find_recurser(dir, parts, find_flags = 0, gave_char_class = false)
       return [] unless dir.respond_to? :[]
       pattern, *parts = parts
       matches =
@@ -139,14 +139,14 @@ module FakeFS
           end
         else
           Globber.expand(pattern).flat_map do |subpattern|
-            dir.matches(Globber.regexp(subpattern, find_flags))
+            dir.matches(Globber.regexp(subpattern, find_flags, gave_char_class))
           end
         end
 
       if parts.empty? # we're done recursing
         matches
       else
-        matches.map { |entry| find_recurser(entry, parts, find_flags) }
+        matches.map { |entry| find_recurser(entry, parts, find_flags, gave_char_class) }
       end
     end
 

--- a/lib/fakefs/globber.rb
+++ b/lib/fakefs/globber.rb
@@ -60,7 +60,7 @@ module FakeFS
       drop_root(result).reject(&:empty?)
     end
 
-    def regexp(pattern, find_flags = 0)
+    def regexp(pattern, find_flags = 0, gave_char_class = false)
       pattern = pattern.to_s
 
       regex_body =
@@ -72,6 +72,12 @@ module FakeFS
         .gsub('(', '\(')
         .gsub(')', '\)')
         .gsub('$', '\$')
+
+      # unless we're expecting character class contructs in regexes, escape all brackets
+      # since if we're expecting them, the string should already be properly escaped
+      unless gave_char_class
+        regex_body = regex_body.gsub('[', '\[').gsub(']', '\]')
+      end
 
       # This matches nested braces and attempts to do something correct most of the time
       # There are known issues (i.e. {,*,*/*}) that cannot be resolved with out a total

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -320,6 +320,29 @@ class FakeFSTest < Minitest::Test
     assert File.writable?(path)
   end
 
+  def test_can_create_files_with_brackets
+    # test various combinations of files with brackets
+    file = '[file'
+    File.open(file, 'w') { |f| f << 'some content' }
+    assert File.exist?(file)
+
+    file = ']file'
+    File.open(file, 'w') { |f| f << 'some content' }
+    assert File.exist?(file)
+
+    file = 'fi][le'
+    File.open(file, 'w') { |f| f << 'some content' }
+    assert File.exist?(file)
+
+    file = '[file]'
+    File.open(file, 'w') { |f| f << 'some content' }
+    assert File.exist?(file)
+
+    file = '[[[[]][[]][]][[[[[[[[]]]'
+    File.open(file, 'w') { |f| f << 'some content' }
+    assert File.exist?(file)
+  end
+
   def test_nothing_is_sticky
     refute File.sticky?('/')
   end
@@ -2362,6 +2385,29 @@ class FakeFSTest < Minitest::Test
   def test_can_create_directories_starting_with_dot
     Dir.mkdir './path'
     assert File.exist? './path'
+  end
+
+  def test_can_create_directories_with_brackets
+    # test various combinations of directories with brackets
+    dir = '/[dir'
+    Dir.mkdir dir
+    assert Dir.exist?(dir)
+
+    dir = '/]dir'
+    Dir.mkdir dir
+    assert Dir.exist?(dir)
+
+    dir = '/[dir]'
+    Dir.mkdir dir
+    assert Dir.exist?(dir)
+
+    dir = '/di][r'
+    Dir.mkdir dir
+    assert Dir.exist?(dir)
+
+    dir = '/[[][][][][[[[]][[[[[[]]]'
+    Dir.mkdir dir
+    assert Dir.exist?(dir)
   end
 
   def test_directory_mkdir_relative


### PR DESCRIPTION
Resolution to issue https://github.com/fakefs/fakefs/issues/267. Allow for brackets in file and directory names.