### PR TITLE
Don't let Dir.chdir cd into files

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -88,6 +88,7 @@ module FakeFS
       dir_levels.push dir if blk
 
       raise Errno::ENOENT, dir unless new_dir
+      raise Errno::ENOTDIR, dir unless File.directory? new_dir
 
       dir_levels.push dir unless blk
       yield(dir) if blk

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1566,6 +1566,19 @@ class FakeFSTest < Minitest::Test
     end
   end
 
+  def test_chdir_raises_error_when_attempting_to_cd_into_a_file
+    File.open('file1', 'w') { |f| f << 'content' }
+    assert_raises(Errno::ENOTDIR) do
+      Dir.chdir('file1')
+    end
+
+    assert_raises(Errno::ENOTDIR) do
+      Dir.chdir('file1') do
+        File.open('file2', 'w') { |f| f << 'content' }
+      end
+    end
+  end
+
   def test_chdir_shouldnt_lose_state_because_of_errors
     FileUtils.mkdir_p '/path'
 


### PR DESCRIPTION
Resolution to issue https://github.com/fakefs/fakefs/issues/292, don't let `Dir.chdir cd` into a file.