### PR TITLE
FileTest.size? is undefined, use FileTest.size for Pathname.size?

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -876,9 +876,9 @@ module FakeFS
       FileTest.setgid?(@path)
     end
 
-    # See <tt>FileTest.size</tt>.
+    # See <tt>FileTest.size?</tt>.
     def size
-      FileTest.size(@path)
+      FileTest.size?(@path)
     end
 
     # See <tt>FileTest.size?</tt>.

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -103,6 +103,16 @@ class PathnameTest < Minitest::Test
     assert_equal Pathname.new('foo') / 'bar', Pathname.new('foo/bar')
   end
 
+  def test_pathname_size?
+    @pathname.write(@path, "some\ncontent")
+    assert_equal 12, @pathname.size?
+  end
+
+  def test_pathname_size
+    @pathname.write(@path, "some\ncontent")
+    assert_equal 12, @pathname.size
+  end
+
   if RUBY_VERSION > '2.4'
     def test_pathname_empty_on_empty_directory
       Dir.mkdir(@path)


### PR DESCRIPTION
Calls to Fake:Pathname#size? break tests and we continually have to stub that method out. The bug stems from FakeFS::Pathname calls FakeFS::FileTest.size? which is undefined:
https://github.com/fakefs/fakefs/blob/master/lib/fakefs/pathname.rb#L884-L887
https://github.com/fakefs/fakefs/blob/master/lib/fakefs/file_test.rb#L18-L20
