### PR TITLE
Fixes #421, raise ENOENT on cp if target parent directory does not exist

### DIFF
--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -100,6 +100,8 @@ module FakeFS
     def cp(src, dest, options = {})
       raise Errno::ENOTDIR, dest.to_s if src.is_a?(Array) && !File.directory?(dest)
 
+      raise Errno::ENOENT, dest.to_s unless File.exist?(dest) || File.exist?(File.dirname(dest))
+
       # handle `verbose' flag
       RealFileUtils.cp src, dest, options.merge(noop: true)
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2420,6 +2420,17 @@ class FakeFSTest < Minitest::Test
     assert Dir.exist? 'bar'
   end
 
+  def test_file_utils_cp_raises_error_on_nonexisting_target
+    FileUtils.touch('file.txt')
+    FileUtils.mkdir('bar')
+
+    perform_with_both_string_paths_and_pathnames do
+      assert_raises Errno::ENOENT do
+        FileUtils.cp(string_or_pathname('file.txt'), string_or_pathname('bar/nonexistent/file.txt'))
+      end
+    end
+  end
+
   def test_copy_file_works
     File.open('foo', 'w') { |f| f.write 'bar' }
     FileUtils.copy_file('foo', 'baz', :ignore_param_1, :ignore_param_2)


### PR DESCRIPTION
This does not include any permissions check stuff and focuses only on the original issue.