### PR TITLE
Fix pathname#write

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -790,7 +790,10 @@ module FakeFS
     def write(string, *args)
       offset = args[0]
       open_args = args[1]
-      IO.write(@path, string, offset, open_args)
+      File.open(@path, open_args || 'w') do |file|
+        file.seek(offset) if offset
+        return file.write(string)
+      end
     end
   end
 

--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -787,10 +787,10 @@ module FakeFS
     end
 
     # See <tt>File.write</tt>. Returns the number of bytes written.
-    def write(path, data)
-      File.open(path, 'wb') do |file|
-        return file.write(data)
-      end
+    def write(string, *args)
+      offset = args[0]
+      open_args = args[1]
+      IO.write(@path, string, offset, open_args)
     end
   end
 

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -94,7 +94,7 @@ class PathnameTest < Minitest::Test
   end
 
   def test_file_is_written
-    @pathname.write(@path, "some\ncontent")
+    @pathname.write("some\ncontent")
 
     assert_equal "some\ncontent", @pathname.read
   end
@@ -104,12 +104,12 @@ class PathnameTest < Minitest::Test
   end
 
   def test_pathname_size?
-    @pathname.write(@path, "some\ncontent")
+    @pathname.write("some\ncontent")
     assert_equal 12, @pathname.size?
   end
 
   def test_pathname_size
-    @pathname.write(@path, "some\ncontent")
+    @pathname.write("some\ncontent")
     assert_equal 12, @pathname.size
   end
 


### PR DESCRIPTION
[ Fix #381 ]

`pathname#write`'s signature is wrong; it has the path as first argument which is absurd since the object itself is the path.

According to [ruby-doc](https://ruby-doc.org/stdlib-2.1.3/libdoc/pathname/rdoc/Pathname.html#method-i-write) the arguments should be:

> write(string, [offset] ) => fixnum
> write(string, [offset], open_args ) => fixnum

This PR changes the code and test to conform to that.