### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: ruby
-sudo: false
+cache: bundler
+
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
-  - 2.6.1
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
   - jruby-1.7.27
   - jruby-9.1.17.0
   - jruby-head
+
 env:
   matrix:
     - TASK=test
     - TASK=spec
+
 matrix:
   allow_failures:
     - rvm: jruby-1.7.27
@@ -21,5 +24,4 @@ matrix:
     - rvm: 2.3.7 # lowest from rvm list above
       env: TASK=rubocop
 
-before_install: gem install bundler
 script: bundle exec rake $TASK


### PR DESCRIPTION
* `sudo: false` is deprecated and removed from Travis CI.
* `cache: bundler` should make testing a bit faster
* Removing the patch version of the Rubies should use the latest version
  available on Travis CI, when they become available.
* bundler is installed by default

Maybe this is a bit much at once, but let's see if it works. :)