### PR TITLE
add Ruby 2.7 to test travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - jruby-1.7.27
   - jruby-9.1.17.0
   - jruby-head


### PR DESCRIPTION
Ruby 2.7 got released some time ago so it makes sense to run the tests
there as well.