### PR TITLE
More fixes for ruby 2.7

### DIFF
--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump', '~> 0.5.3'
   spec.add_development_dependency 'minitest', '~> 5.5'
   spec.add_development_dependency 'minitest-rg', '~> 5.1'
-  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'rake', '>= 10.3'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '~> 0.58.1'
 end

--- a/lib/fakefs/base.rb
+++ b/lib/fakefs/base.rb
@@ -16,7 +16,7 @@ end
 module FakeFS
   class << self
     def activated?
-      @activated ? true : false
+      @activated ||= false
     end
 
     # unconditionally activate

--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -202,7 +202,7 @@ module FakeFS
         n = nil
         begin
           path = File.join(tmpdir, make_tmpname(basename, n))
-          yield(path, n, **opts)
+          yield(path, n, opts)
         rescue Errno::EEXIST
           n ||= 0
           n += 1

--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -92,7 +92,7 @@ module FakeFS
     end
 
     def self.children(dirname, opts = {})
-      entries(dirname, opts) - ['.', '..']
+      entries(dirname, **opts) - ['.', '..']
     end
 
     def self.each_child(dirname, &_block)

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -497,8 +497,8 @@ module FakeFS
       true
     end
 
-    def write(str)
-      val = super(str)
+    def write(*args)
+      val = super(*args)
       @file.mtime = Time.now
       val
     end

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -183,7 +183,7 @@ module FakeFS
       options = args[-1].is_a?(Hash) ? args.pop : {}
       length = args.empty? ? nil : args.shift
       offset = args.empty? ? 0 : args.shift
-      file = new(path, options)
+      file = new(path, **options)
 
       raise Errno::ENOENT unless file.exists?
       raise Errno::EISDIR, path.to_s if directory?(path)

--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -66,11 +66,11 @@ module FakeFS
     alias remove rm
 
     def rm_f(list, options = {})
-      rm(list, options.merge(force: true))
+      rm(list, **options.merge(force: true))
     end
 
     def rm_rf(list, options = {})
-      rm_r(list, options.merge(force: true))
+      rm_r(list, **options.merge(force: true))
     end
     alias rmtree rm_rf
     alias safe_unlink rm_f
@@ -103,7 +103,7 @@ module FakeFS
       raise Errno::ENOENT, dest.to_s unless File.exist?(dest) || File.exist?(File.dirname(dest))
 
       # handle `verbose' flag
-      RealFileUtils.cp src, dest, options.merge(noop: true)
+      RealFileUtils.cp src, dest, **options.merge(noop: true)
 
       # handle `noop' flag
       return if options[:noop]
@@ -145,7 +145,7 @@ module FakeFS
 
     def cp_r(src, dest, options = {})
       # handle `verbose' flag
-      RealFileUtils.cp_r src, dest, options.merge(noop: true)
+      RealFileUtils.cp_r src, dest, **options.merge(noop: true)
 
       # handle `noop' flag
       return if options[:noop]
@@ -176,7 +176,7 @@ module FakeFS
 
     def mv(src, dest, options = {})
       # handle `verbose' flag
-      RealFileUtils.mv src, dest, options.merge(noop: true)
+      RealFileUtils.mv src, dest, **options.merge(noop: true)
 
       # handle `noop' flag
       return if options[:noop]

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2188,14 +2188,14 @@ class FakeFSTest < Minitest::Test
         Dir.chdir(path) do
           raise Errno::ENOENT
         end
-      rescue Errno::ENOENT => e # hardcore
+      rescue Errno::ENOENT # hardcore
         'Nothing to do'
       end
 
       Dir.chdir(path) do
         begin
           Dir.chdir(string_or_pathname('nope')) {}
-        rescue Errno::ENOENT => e
+        rescue Errno::ENOENT
           'Nothing to do'
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,17 @@ def act_on_real_fs(&block)
   FakeFS.without(&block)
 end
 
+module Minitest
+  class Test
+    # Minitest::Test#diff needs to write to the filesystem in order to produce
+    # the nice diffs we see when a test fails. For this to work it needs to
+    # access the real filesystem.
+    def diff(expected, actual)
+      act_on_real_fs { super(expected, actual) }
+    end
+  end
+end
+
 def capture_stderr
   real_stderr, $stderr = $stderr, StringIO.new
 


### PR DESCRIPTION
This PR fixes the intermittent test failures on ruby 2.7 (#439), and removes
all warnings when running the tests.