### PR TITLE
Remove mockfs from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,6 @@ FakeFS::File.class_eval do
 end
 ```
 
-[MockFS](http://mockfs.rubyforge.org/) comparison
-----------------------------------
-
-FakeFS provides a test suite and works with symlinks. It's also strictly a
-test-time dependency: your actual library does not need to use or know about
-FakeFS.
-
-
 Caveats
 -------
 


### PR DESCRIPTION
It might not be necessary to include mockfs in the readme as it seems unmaintained for over ten years: https://rubygems.org/gems/mockfs/versions

The homepage for mockfs isn't accessible either: http://mockfs.rubyforge.org/


