### PR TITLE
Fix irregularity with File.rename

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -231,6 +231,8 @@ module FakeFS
       end
 
       if (target = FileSystem.find(source))
+        return 0 if source == dest
+
         if target.is_a?(FakeFS::FakeSymlink)
           File.symlink(target.target, dest)
         else

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -3220,7 +3220,23 @@ class FakeFSTest < Minitest::Test
     FileUtils.touch('/foo')
     FileUtils.touch('/bar')
     File.rename('/foo', '/bar')
+    assert !File.exist?('/foo')
+    assert File.exist?('/bar')
     assert File.file?('/bar')
+  end
+
+  def test_rename_file_to_itself
+    FileUtils.touch('/foo')
+    File.rename('/foo', '/foo')
+    assert File.exist?('/foo')
+    assert File.file?('/foo')
+  end
+
+  def test_rename_non_existing_file_to_itself_raises_error
+    assert_raises(Errno::ENOENT) do
+      File.rename('/foo', '/foo')
+    end
+    assert !File.exist?('/foo')
   end
 
   def test_rename_renames_a_directories


### PR DESCRIPTION
When passing the same path for the `source` and `dest` e.g. `FakeFS::File.rename('/file', '/file')`, the file will get deleted by `FileSystem.delete(source)` then a `0` will get returned.

This is erroneous behaviour, the file '/file' should still exist and the `0` returned. See the example below comparing `FakeFS::File.rename` with `File.rename`:

```ruby
irb(main):001:0> require 'fakefs'
=> true
irb(main):002:0> app_path = '/usr/src/app'
=> "/usr/src/app"
irb(main):003:0> FakeFS.activate!
=> true
irb(main):004:0> FakeFS::FileSystem.clone app_path
=> ["/usr/src/app/test"]
irb(main):005:0> file_path = "#{app_path}/test"
=> "/usr/src/app/test"
irb(main):006:0> FakeFS::File.exist? file_path
=> true
irb(main):007:0> FakeFS::File.rename file_path, file_path
=> 0
irb(main):008:0> FakeFS::File.exist? file_path
=> false
irb(main):009:0> FakeFS.deactivate!
=> true
irb(main):010:0> FakeFS.clear!
=> nil
irb(main):011:0> File.exist? file_path
=> true
irb(main):012:0> File.rename file_path, file_path
=> 0
irb(main):013:0> File.exist? file_path
=> true
```