### PR TITLE
File.readlines supports `:chomp` option

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -197,11 +197,11 @@ module FakeFS
       file.read(length)
     end
 
-    def self.readlines(path, options = {})
+    def self.readlines(path, chomp: false)
       file = new(path)
       if file.exists?
         FileSystem.find(path).atime = Time.now
-        options[:chomp] ? file.readlines.map(&:chomp) : file.readlines
+        chomp ? file.readlines.map(&:chomp) : file.readlines
       else
         raise Errno::ENOENT
       end

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -197,11 +197,11 @@ module FakeFS
       file.read(length)
     end
 
-    def self.readlines(path)
+    def self.readlines(path, options = {})
       file = new(path)
       if file.exists?
         FileSystem.find(path).atime = Time.now
-        file.readlines
+        options[:chomp] ? file.readlines.map(&:chomp) : file.readlines
       else
         raise Errno::ENOENT
       end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1204,7 +1204,7 @@ class FakeFSTest < Minitest::Test
         f.write "this\nis\na\ntest\n"
       end
 
-      assert_equal ["this", "is", "a", "test"], File.readlines(path, chomp: true)
+      assert_equal ['this', 'is', 'a', 'test'], File.readlines(path, chomp: true)
       FileUtils.rm(path)
     end
   end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1197,6 +1197,18 @@ class FakeFSTest < Minitest::Test
     end
   end
 
+  def test_can_read_with_File_readlines_with_chomp
+    perform_with_both_string_paths_and_pathnames do
+      path = string_or_pathname('file.txt')
+      File.open(path, 'w') do |f|
+        f.write "this\nis\na\ntest\n"
+      end
+
+      assert_equal ["this", "is", "a", "test"], File.readlines(path, chomp: true)
+      FileUtils.rm(path)
+    end
+  end
+
   def test_can_read_with_File_foreach
     perform_with_both_string_paths_and_pathnames do
       path = string_or_pathname('file.txt')


### PR DESCRIPTION
Fixes #453 