### PR TITLE
FIx Dir.glob fails to return matches when a path contains plus sign(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+- Fix `Dir.glob` fails to return correct matches when a path contains plus sign(s)
 
 ## 1.2.0
 

--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -120,11 +120,13 @@ module FakeFS
     def self.glob(pattern, flags = 0, &block)
       matches_for_pattern = lambda do |matcher|
         [FileSystem.find(matcher, flags, true) || []].flatten.map do |e|
-          if Dir.pwd.match(%r{\A/?\z}) ||
-             !e.to_s.match(%r{\A#{Dir.pwd}/?})
+          pwd = Dir.pwd
+          pwd_regex = %r{\A#{pwd.gsub('+') { '\+' }}/?}
+          if pwd.match(%r{\A/?\z}) ||
+             !e.to_s.match(pwd_regex)
             e.to_s
           else
-            e.to_s.match(%r{\A#{Dir.pwd}/?}).post_match
+            e.to_s.match(pwd_regex).post_match
           end
         end.sort
       end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1834,6 +1834,22 @@ class FakeFSTest < Minitest::Test
     assert_equal ['/tmp/python-2.7.8', '/tmp/python-3.4.1'], Dir.glob('/tmp/python-[0-9]*')
   end
 
+  def test_dir_glob_plus_sign_in_dir_name
+    FileUtils.mkdir_p '/abc+cde/python-3.4.1'
+    FileUtils.mkdir_p '/abc+cde/python-2.7.8'
+    Dir.chdir('/abc+cde') do
+      assert_equal ['python-2.7.8', 'python-3.4.1'], Dir.glob('**/*')
+    end
+  end
+
+  def test_dir_glob_plus_signs_in_dir_name
+    FileUtils.mkdir_p '/abc+cde+123/python-3.4.1'
+    FileUtils.mkdir_p '/abc+cde+123/python-2.7.8'
+    Dir.chdir('/abc+cde+123') do
+      assert_equal ['python-2.7.8', 'python-3.4.1'], Dir.glob('**/*')
+    end
+  end
+
   def test_dir_glob_respects_fnm_dotmatch
     File.open('/file', 'w') { |f| f << 'content' }
     File.open('/.file_hidden', 'w') { |f| f << 'content' }


### PR DESCRIPTION
Addresses issue: https://github.com/fakefs/fakefs/issues/451

The fix is making use of an existing fix from https://github.com/fakefs/fakefs/issues/133 where I simply do a gsub to make sure all `+` becomes `\+`
Tried to use Globber.regexp method but no luck there because it returned a fixed regex that is not what we want, maybe there is another method I can use?

First time contributing, let me know if anything else needed to be changed. 🙏 