### PR TITLE
Allow redefined Dir.glob to disable gave_char_class

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -117,9 +117,9 @@ module FakeFS
       Dir.open(dirname) { |file| yield file }
     end
 
-    def self.glob(pattern, flags = 0, &block)
+    def self.glob(pattern, flags = 0, match = true, &block)
       matches_for_pattern = lambda do |matcher|
-        [FileSystem.find(matcher, flags, true) || []].flatten.map do |e|
+        [FileSystem.find(matcher, flags, match) || []].flatten.map do |e|
           pwd = Dir.pwd
           pwd_regex = %r{\A#{pwd.gsub('+') { '\+' }}/?}
           if pwd.match(%r{\A/?\z}) ||


### PR DESCRIPTION
While attempting to use fakefs, I ran into an issue where I wanted to disable the `gave_char_class` option in your custom `Dir.glob` call, but was unable to because you have it hard coded to true.

This PR makes a simple tweak that makes it configurable, while maintaining backwards compatibility since it defaults to true.