### PR TITLE
Don't escape characters that are already escaped

### DIFF
--- a/lib/fakefs/globber.rb
+++ b/lib/fakefs/globber.rb
@@ -63,20 +63,21 @@ module FakeFS
     def regexp(pattern, find_flags = 0, gave_char_class = false)
       pattern = pattern.to_s
 
+      # Escape .+?*()$ characters unless already escaped.
       regex_body =
         pattern
-        .gsub('.', '\.')
-        .gsub('+') { '\+' }
-        .gsub('?', '.')
-        .gsub('*', '.*')
-        .gsub('(', '\(')
-        .gsub(')', '\)')
-        .gsub('$', '\$')
+        .gsub(/(?<!\\)\./, '\.')
+        .gsub(/(?<!\\)\+/) { '\+' }
+        .gsub(/(?<!\\)\?/, '.')
+        .gsub(/(?<!\\)\*/, '.*')
+        .gsub(/(?<!\\)\(/, '\(')
+        .gsub(/(?<!\\)\)/, '\)')
+        .gsub(/(?<!\\)\$/, '\$')
 
-      # unless we're expecting character class contructs in regexes, escape all brackets
-      # since if we're expecting them, the string should already be properly escaped
+      # Unless we're expecting character class contructs in regexes, escape all brackets
+      # since if we're expecting them, the string should already be properly escaped.
       unless gave_char_class
-        regex_body = regex_body.gsub('[', '\[').gsub(']', '\]')
+        regex_body = regex_body.gsub(/(?<!\\)([\[\]])/, '\\\\\1')
       end
 
       # This matches nested braces and attempts to do something correct most of the time

--- a/test/globber_test.rb
+++ b/test/globber_test.rb
@@ -45,4 +45,12 @@ class GlobberTest < Minitest::Test
   def test_regexp_accepts_nested_brace_groups_with_plus
     assert_equal(/\Aa(\.(b)|)(\.(c)|)(\+()|)(\.(d|e|f)|)\Z/.to_s, FakeFS::Globber.regexp('a{.{b},}{.{c},}{+{},}{.{d,e,f},}').to_s)
   end
+
+  def test_regexp_accepts_special_characters
+    assert_equal(%r{\A/a/\[b\]/\(c\)\Z}.to_s, FakeFS::Globber.regexp('/a/[b]/(c)').to_s)
+  end
+
+  def test_regexp_accepts_already_escaped_special_characters
+    assert_equal(%r{\A/a/\[b\]/\(c\)\Z}.to_s, FakeFS::Globber.regexp('/a/\[b\]/\(c\)').to_s)
+  end
 end


### PR DESCRIPTION
In my attempt to use fakefs with my file-find library, I ran into an issue where fakefs would escape characters that I had already escaped, resulting in issues.

This PR uses negative lookbehind so that it `Globber#regexp` doesn't escape things that are already escaped. The current tests still pass, and I also added a couple tests.