### PR TITLE
Add Ruby 3.0 to test matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', 'jruby-head' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', 'jruby-head' ]
         task: [test, spec]
         include:
         # run rubocop against lowest supported ruby


### PR DESCRIPTION
Hi @grosser,

I noticed that the GitHub action is not running tests with Ruby 3.0 and I thought it should.

I just tested this in my local environment and everything seems to work fine with Ruby 3.0.

Please check it out.

Thanks! 