### PR TITLE
Fix syntax in cloning example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ FakeFS do
   FakeFS::FileSystem.clone(config)
   expect(File.read("#{config}/foo.yml")).to include("original-content-of-foo")
 
-  File.write("#{config}/foo.yml"), "NEW")
+  File.write(("#{config}/foo.yml"), "NEW")
   expect(File.read("#{config}/foo.yml")).to eq "NEW"
 end
 ```


### PR DESCRIPTION
Adds missing open parenthesis

I noticed this while experimenting with a basis of the example code.