### PR TITLE
Implement Pathname#glob, update signature for Dir.glob

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -117,7 +117,7 @@ module FakeFS
       Dir.open(dirname) { |file| yield file }
     end
 
-    def self.glob(pattern, flags = 0, &block)
+    def self.glob(pattern, _flags = 0, flags: _flags, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
       matches_for_pattern = lambda do |matcher|
         [FileSystem.find(matcher, flags, true) || []].flatten.map do |e|
           pwd = Dir.pwd

--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -117,10 +117,10 @@ module FakeFS
       Dir.open(dirname) { |file| yield file }
     end
 
-    def self.glob(pattern, _flags = 0, flags: _flags, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
+    def self.glob(pattern, _flags = 0, flags: _flags, base: nil, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
+      pwd = FileSystem.normalize_path(base || Dir.pwd)
       matches_for_pattern = lambda do |matcher|
-        [FileSystem.find(matcher, flags, true) || []].flatten.map do |e|
-          pwd = Dir.pwd
+        [FileSystem.find(matcher, flags, true, dir: pwd) || []].flatten.map do |e|
           pwd_regex = %r{\A#{pwd.gsub('+') { '\+' }}/?}
           if pwd.match(%r{\A/?\z}) ||
              !e.to_s.match(pwd_regex)

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -20,12 +20,12 @@ module FakeFS
       fs.entries
     end
 
-    def find(path, find_flags = 0, gave_char_class = false)
-      parts = path_parts(normalize_path(path))
+    def find(path, find_flags = 0, gave_char_class = false, dir: nil)
+      parts = path_parts(normalize_path(path, dir: dir))
       return fs if parts.empty? # '/'
 
       entries = Globber.expand(path).flat_map do |pattern|
-        parts = path_parts(normalize_path(pattern))
+        parts = path_parts(normalize_path(pattern, dir: dir))
         find_recurser(fs, parts, find_flags, gave_char_class).flatten
       end
 
@@ -100,11 +100,13 @@ module FakeFS
       Globber.path_components(path)
     end
 
-    def normalize_path(path)
+    def normalize_path(path, dir: nil)
       if Pathname.new(path).absolute?
         RealFile.expand_path(path)
       else
-        parts = dir_levels + [path]
+        dir ||= dir_levels
+        dir = Array(dir)
+        parts = dir + [path]
         RealFile.expand_path(parts.reduce do |base, part|
                                Pathname(base) + part
                              end.to_s)

--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -953,6 +953,14 @@ module FakeFS
     def opendir(&block) # :yield: dir
       Dir.open(@path, &block)
     end
+
+    def glob(pattern, flags = 0)
+      if block_given?
+        Dir.glob(pattern, flags: flags, base: self) { |f| yield join(f) }
+      else
+        Dir.glob(pattern, flags: flags, base: self).map { |f| join(f) }
+      end
+    end
   end
 
   # Pathname class

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1828,6 +1828,15 @@ class FakeFSTest < Minitest::Test
     assert_equal ['/.foo', '/tmp'], Dir.glob('/*', flags: File::FNM_DOTMATCH)
   end
 
+  def test_dir_glob_takes_base
+    FileUtils.mkdir_p '/foo/bar'
+    FileUtils.touch '/foo/bar/one'
+    FileUtils.touch '/foo/bar/two'
+    Dir.chdir('/foo') do
+      assert_equal ['one', 'two'], Dir.glob('*', base: 'bar')
+    end
+  end
+
   def test_dir_glob_handles_recursive_globs
     FileUtils.mkdir_p '/one/two/three'
     File.open('/one/two/three/four.rb', 'w')

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1823,6 +1823,11 @@ class FakeFSTest < Minitest::Test
     assert_equal ['/.foo', '/tmp'], Dir.glob('/*', File::FNM_DOTMATCH)
   end
 
+  def test_dir_glob_takes_optional_flags_as_keyword
+    FileUtils.touch '/.foo'
+    assert_equal ['/.foo', '/tmp'], Dir.glob('/*', flags: File::FNM_DOTMATCH)
+  end
+
   def test_dir_glob_handles_recursive_globs
     FileUtils.mkdir_p '/one/two/three'
     File.open('/one/two/three/four.rb', 'w')

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1819,8 +1819,8 @@ class FakeFSTest < Minitest::Test
   end
 
   def test_dir_glob_takes_optional_flags
-    FileUtils.touch '/foo'
-    assert_equal ['/foo', '/tmp'], Dir.glob('/*', 0)
+    FileUtils.touch '/.foo'
+    assert_equal ['/.foo', '/tmp'], Dir.glob('/*', File::FNM_DOTMATCH)
   end
 
   def test_dir_glob_handles_recursive_globs

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1820,7 +1820,7 @@ class FakeFSTest < Minitest::Test
 
   def test_dir_glob_takes_optional_flags
     FileUtils.touch '/foo'
-    assert_equal Dir.glob('/*', 0), ['/foo', '/tmp']
+    assert_equal ['/foo', '/tmp'], Dir.glob('/*', 0)
   end
 
   def test_dir_glob_handles_recursive_globs

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -113,6 +113,31 @@ class PathnameTest < Minitest::Test
     assert_equal 12, @pathname.size
   end
 
+  def test_pathname_glob
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('.zero'))
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    assert_equal [Pathname.new('/foo/one'), Pathname.new('/foo/two')], @pathname.glob('*')
+  end
+
+  def test_pathname_glob_takes_flags
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('.zero'))
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    assert_equal [Pathname.new('/foo/.zero'), Pathname.new('/foo/one'), Pathname.new('/foo/two')], @pathname.glob('*', File::FNM_DOTMATCH)
+  end
+
+  def test_pathname_glob_block
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    result = []
+    @pathname.glob('*') { |pathname| result << pathname }
+    assert_equal [Pathname.new('/foo/one'), Pathname.new('/foo/two')], result
+  end
+
   if RUBY_VERSION > '2.4'
     def test_pathname_empty_on_empty_directory
       Dir.mkdir(@path)

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -138,6 +138,48 @@ class PathnameTest < Minitest::Test
     assert_equal [Pathname.new('/foo/one'), Pathname.new('/foo/two')], result
   end
 
+  def test_pathname_glob_class_method
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('.zero'))
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    assert_equal [Pathname.new('/foo/one'), Pathname.new('/foo/two')], Pathname.glob(@pathname.join('*'))
+  end
+
+  def test_pathname_glob_class_method_block
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    result = []
+    Pathname.glob(@pathname.join('*')) { |pathname| result << pathname }
+    assert_equal [Pathname.new('/foo/one'), Pathname.new('/foo/two')], result
+  end
+
+  def test_pathname_glob_class_method_flags
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('.zero'))
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    assert_equal [Pathname.new('/foo/.zero'), Pathname.new('/foo/one'), Pathname.new('/foo/two')], Pathname.glob(@pathname.join('*'), File::FNM_DOTMATCH)
+  end
+
+  def test_pathname_glob_class_method_flags_as_keyword
+    FileUtils.mkdir(@pathname)
+    FileUtils.touch(@pathname.join('.zero'))
+    FileUtils.touch(@pathname.join('one'))
+    FileUtils.touch(@pathname.join('two'))
+    assert_equal [Pathname.new('/foo/.zero'), Pathname.new('/foo/one'), Pathname.new('/foo/two')], Pathname.glob(@pathname.join('*'), flags: File::FNM_DOTMATCH)
+  end
+
+  def test_pathname_glob_class_method_takes_base
+    FileUtils.mkdir_p @pathname.join('bar')
+    FileUtils.touch @pathname.join('bar', 'one')
+    FileUtils.touch @pathname.join('bar', 'two')
+    Dir.chdir(@pathname) do
+      assert_equal [Pathname.new('one'), Pathname.new('two')], Pathname.glob('*', base: 'bar')
+    end
+  end
+
   if RUBY_VERSION > '2.4'
     def test_pathname_empty_on_empty_directory
       Dir.mkdir(@path)


### PR DESCRIPTION
This method was added in Ruby 2.4

The changes to Dir.glob were added in ruby 2.5 (base) and ruby 3.0 (flags as keyword arg), however it's harder to match those (I can take a stab if you want though).

Any feedback is welcome!

Addresses #465 
