### PR TITLE
Add Ruby 3.1 and ruby-head to CI and fix undef that fails on ruby-head

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', 'jruby-head' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head', 'jruby-head' ]
         task: [test, spec]
         include:
         # run rubocop against lowest supported ruby

--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -1035,6 +1035,6 @@ module FakeFS
 
   # Pathname class
   class Pathname
-    undef =~
+    undef =~ if respond_to?(:=~)
   end
 end


### PR DESCRIPTION
This PR updates the CI matrix to include Ruby 3.1 and ruby-head.

To get ruby-head green I added a `respond_to?` guard around the undef of `=~`, as Pathname does not respond to that method in Ruby 3.2.

JRuby-head is failing, but for reasons unrelated to this PR.