### PR TITLE
Fix ::File.write incorrect opening mode

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -658,7 +658,7 @@ module FakeFS
 
     def self.write(filename, contents, offset = nil, open_args = {})
       offset, open_args = nil, offset if offset.is_a?(Hash)
-      mode = offset ? 'a' : 'w'
+      mode = offset ? 'r+' : 'w'
       if open_args.any?
         if open_args[:open_args]
           args = [filename, *open_args[:open_args]]

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -4247,6 +4247,8 @@ class FakeFSTest < Minitest::Test
 
     File.write('foo', 'bar', 3)
     assert_equal File.read('foo'), 'foobar'
+    File.write('foo', 'baz', 3)
+    assert_equal File.read('foo'), 'foobaz'
   end
 
   def test_can_read_binary_data_in_binary_mode


### PR DESCRIPTION
When writing to an existing file at a specific offset the new content should replace the previous content instead of being appended to it.
The former test was equivalent to an append so it missed this incorrect behavior.