### PR TITLE
fix: pass arguments to File.dirname

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -174,8 +174,8 @@ module FakeFS
       RealFile.basename(*args)
     end
 
-    def self.dirname(path)
-      RealFile.dirname(path)
+    def self.dirname(*args)
+      RealFile.dirname(*args)
     end
 
     def self.readlink(path)


### PR DESCRIPTION
Ruby 3.1.0 introduced optional second argument on `File.dirname`. See https://rubyreferences.github.io/rubychanges/3.1.html#filedirname-optional-level-to-go-up-the-directory-tree

This change passes any arguments to the RealFile to support this change across different ruby versions.

I was looking for a unit test for this but could not find any. If there is one, please let me know and I will update the tests too.