### PR TITLE
Support File.binmode?

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -619,7 +619,10 @@ module FakeFS
     end
 
     def binmode?
-      raise NotImplementedError
+      @mode.is_a?(String) && (
+        @mode.include?('b') ||
+        @mode.include?('binary')
+      ) && !@mode.include?('bom')
     end
 
     def close_on_exec=(_bool)
@@ -697,7 +700,7 @@ module FakeFS
 
     def read(length = nil, buf = '')
       read_buf = super(length, buf)
-      if binary_mode?
+      if binmode?
         read_buf&.force_encoding('ASCII-8BIT')
       else
         read_buf&.force_encoding(Encoding.default_external)
@@ -862,13 +865,6 @@ module FakeFS
 
     def check_modes!
       StringIO.new('', @mode)
-    end
-
-    def binary_mode?
-      @mode.is_a?(String) && (
-        @mode.include?('b') ||
-        @mode.include?('binary')
-      ) && !@mode.include?('bom')
     end
 
     def check_file_existence!

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -4189,6 +4189,15 @@ class FakeFSTest < Minitest::Test
     end
   end
 
+  def test_binmode
+    File.open('foo', 'w') do |f|
+      assert_equal false, f.binmode?
+    end
+    File.open('foo', 'wb') do |f|
+      assert_equal true, f.binmode?
+    end
+  end
+
   def test_to_path
     File.open('foo', 'w') do |f|
       assert_equal 'foo', f.to_path


### PR DESCRIPTION
The FakeFS File class had a private method named `binary_mode?` which is pretty much doing what you want, let's just expose it publicly!