### PR TITLE
Assign FS constants to make them available in Pry

### DIFF
--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 10.3'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '~> 0.82.0'
+  spec.add_development_dependency 'pry'
 end

--- a/lib/fakefs/pry.rb
+++ b/lib/fakefs/pry.rb
@@ -1,0 +1,9 @@
+# Define Pry class if it's not defined. Useful if pry
+# is required after loading FakeFS
+::Pry = Class.new unless defined?(::Pry)
+
+# Make the original file system classes available in Pry.
+::Pry::File = ::File
+::Pry::FileUtils = ::FileUtils
+::Pry::Dir = ::Dir
+::Pry::Pathname = ::Pathname

--- a/lib/fakefs/safe.rb
+++ b/lib/fakefs/safe.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'pathname'
+require 'fakefs/pry'
 require 'fakefs/base'
 require 'fakefs/fake/file'
 require 'fakefs/fake/dir'

--- a/test/pry_test.rb
+++ b/test/pry_test.rb
@@ -1,0 +1,21 @@
+require_relative 'test_helper'
+
+require 'pry'
+
+class PryTest < Minitest::Test
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def test_show_source
+    Pry.run_command("show-source FakeFS.activate!", show_output: false)
+    assert_nil Pry.last_internal_error
+  end
+end


### PR DESCRIPTION
When `binding.pry` is used when `FakeFS` is activated, Pry is unable to use commands that load files from the real file system. The most obvious case is `show-source` that ends up with an error:

```ruby
require 'fakefs'

RSpec.describe 'pry inside FakeFS' do
  it 'shows method source' do
    require 'pry'; binding.pry
  end
end
```

```
[1] pry> show-source FakeFS
Error: Couldn't locate a definition for FakeFS
```

This happens because filesystem classes are stubbed globally, so even Pry uses the fake file system.

To fix this, I assigned filesystem classes inside the `Pry` class. Pry uses the default constant access (without the top-level `::`, e.g. https://github.com/pry/pry/blob/7642967041746d63ae37adb126687c9ec58d3faa/lib/pry/code/code_file.rb#L74). When we assign the filesystem constants inside `Pry` class, they will be used instead of the top-level ones mocked by FakeFS.

There is a similar issue with IRB, but fixing it requires also unhijacking the `Kernel#open` method, so I believe it can be covered in a separate PR. I've described the [IRB problem in a separate issue](https://github.com/fakefs/fakefs/issues/484).
