### PR TITLE
Make Dir.open with block compatible with ::Dir. Fixes #449

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -37,6 +37,10 @@ module FakeFS
       end
     end
 
+    def children
+      each.to_a
+    end
+
     def pos
       @pointer
     end
@@ -96,9 +100,11 @@ module FakeFS
     end
 
     def self.each_child(dirname, &_block)
-      Dir.open(dirname) do |file|
-        next if ['.', '..'].include?(file)
-        yield file
+      Dir.open(dirname) do |dir|
+        dir.each do |file|
+          next if ['.', '..'].include?(file)
+          yield file
+        end
       end
     end
 
@@ -114,7 +120,11 @@ module FakeFS
     end
 
     def self.foreach(dirname, &_block)
-      Dir.open(dirname) { |file| yield file }
+      Dir.open(dirname) do |dir|
+        dir.each do |file|
+          yield file
+        end
+      end
     end
 
     def self.glob(pattern, _flags = 0, flags: _flags, base: nil, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
@@ -152,10 +162,13 @@ module FakeFS
     end
 
     def self.open(string, &_block)
+      dir = Dir.new(string)
       if block_given?
-        Dir.new(string).each { |file| yield(file) }
+        result = yield(dir)
+        dir.close
+        result
       else
-        Dir.new(string)
+        dir
       end
     end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -3205,13 +3205,12 @@ class FakeFSTest < Minitest::Test
       FileUtils.touch("/this/path/should/be/here/#{f}")
     end
 
-    yielded = []
-    Dir.open('/this/path/should/be/here') do |dir|
-      yielded << dir
+    children = Dir.open('/this/path/should/be/here') do |dir|
+      dir.children
     end
 
-    assert yielded.size == test.size
-    test.each { |t| assert yielded.include?(t) }
+    assert children.size == test.size
+    test.each { |t| assert children.include?(t) }
   end
 
   def test_directory_exists


### PR DESCRIPTION
When `Dir.open` is called with the block, yield this block on the dir being opened and then close that dir. This is to make `FakeFS::Dir.open` compatible with Ruby's `::Dir.open`.

Fixes https://github.com/fakefs/fakefs/issues/449.
