### PR TITLE
Do not expand globs in FileSystem.find

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -120,7 +120,7 @@ module FakeFS
     def self.glob(pattern, _flags = 0, flags: _flags, base: nil, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
       pwd = FileSystem.normalize_path(base || Dir.pwd)
       matches_for_pattern = lambda do |matcher|
-        [FileSystem.find(matcher, flags, true, dir: pwd) || []].flatten.map do |e|
+        [FileSystem.find_with_glob(matcher, flags, true, dir: pwd) || []].flatten.map do |e|
           pwd_regex = %r{\A#{pwd.gsub('+') { '\+' }}/?}
           if pwd.match(%r{\A/?\z}) ||
              !e.to_s.match(pwd_regex)

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -46,7 +46,7 @@ module FakeFS
         referent = File.expand_path(File.readlink(path), File.dirname(path))
         exist?(referent)
       else
-        !FileSystem.find_verbatim(path).nil?
+        !FileSystem.find(path).nil?
       end
     end
 
@@ -493,7 +493,7 @@ module FakeFS
     def initialize(path, mode = READ_ONLY, _perm = nil)
       @path = path
       @mode = mode.is_a?(Hash) ? (mode[:mode] || READ_ONLY) : mode
-      @file = FileSystem.find_verbatim(path)
+      @file = FileSystem.find(path)
       @autoclose = true
 
       check_modes!

--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -46,7 +46,7 @@ module FakeFS
         referent = File.expand_path(File.readlink(path), File.dirname(path))
         exist?(referent)
       else
-        !FileSystem.find(path).nil?
+        !FileSystem.find_verbatim(path).nil?
       end
     end
 
@@ -493,7 +493,7 @@ module FakeFS
     def initialize(path, mode = READ_ONLY, _perm = nil)
       @path = path
       @mode = mode.is_a?(Hash) ? (mode[:mode] || READ_ONLY) : mode
-      @file = FileSystem.find(path)
+      @file = FileSystem.find_verbatim(path)
       @autoclose = true
 
       check_modes!

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -24,16 +24,7 @@ module FakeFS
       parts = path_parts(normalize_path(path, dir: dir))
       return fs if parts.empty? # '/'
 
-      entries = [path].flat_map do |pattern|
-        parts = path_parts(normalize_path(pattern, dir: dir))
-        find_recurser_verbatim(fs, parts).flatten
-      end
-
-      case entries.length
-      when 0 then nil
-      when 1 then entries.first
-      else entries
-      end
+      find_recurser_verbatim(fs, parts)
     end
     alias_method :find, :find_verbatim
 
@@ -137,17 +128,14 @@ module FakeFS
     private
 
     def find_recurser_verbatim(dir, parts, find_flags = 0, gave_char_class = false)
-      return [] unless dir.respond_to? :[]
-      pattern, *parts = parts
-      matches =
-        [pattern].flat_map do |subpattern|
-          dir.entries.find{|e| e.name == subpattern}
-        end
+      return nil unless dir.respond_to? :[]
+      head, *parts = parts
+      match = dir.entries.find { |e| e.name == head }
 
       if parts.empty? # we're done recursing
-        matches
+        match
       else
-        matches.map { |entry| find_recurser_verbatim(entry, parts, find_flags, gave_char_class) }
+        find_recurser_verbatim(match, parts, find_flags, gave_char_class)
       end
     end
 

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -20,6 +20,7 @@ module FakeFS
       fs.entries
     end
 
+    # Finds files/directories using the exact path, without expanding globs.
     def find(path, dir: nil)
       parts = path_parts(normalize_path(path, dir: dir))
       return fs if parts.empty? # '/'
@@ -27,6 +28,7 @@ module FakeFS
       find_recurser(fs, parts)
     end
 
+    # Finds files/directories expanding globs.
     def find_with_glob(path, find_flags = 0, gave_char_class = false, dir: nil)
       parts = path_parts(normalize_path(path, dir: dir))
       return fs if parts.empty? # '/'

--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -35,8 +35,9 @@ module FakeFS
       else entries
       end
     end
+    alias_method :find, :find_verbatim
 
-    def find(path, find_flags = 0, gave_char_class = false, dir: nil)
+    def find_with_glob(path, find_flags = 0, gave_char_class = false, dir: nil)
       parts = path_parts(normalize_path(path, dir: dir))
       return fs if parts.empty? # '/'
 

--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -232,7 +232,7 @@ module FakeFS
       list = Array(list)
       list.each do |file|
         chown(user, group, file)
-        [FileSystem.find("#{file}/**/**")].flatten.each do |f|
+        [FileSystem.find_with_glob("#{file}/**/**")].flatten.each do |f|
           chown(user, group, f.to_s)
         end
       end
@@ -255,7 +255,7 @@ module FakeFS
       list = Array(list)
       list.each do |file|
         chmod(mode, file)
-        [FileSystem.find("#{file}/**/**")].flatten.each do |f|
+        [FileSystem.find_with_glob("#{file}/**/**")].flatten.each do |f|
           chmod(mode, f.to_s)
         end
       end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -616,6 +616,28 @@ class FakeFSTest < Minitest::Test
       end
     end
   end
+require 'pry';
+  def test_globs_in_exist
+    perform_with_both_string_paths_and_pathnames do
+      # require 'pry'; binding.pry
+      Dir.mkdir(string_or_pathname("a"))
+      File.write(string_or_pathname("a/1.txt"), "a");
+      assert_equal File.exist?("**/*.txt"), false
+      assert_equal File.exist?("a/1.txt"), true
+
+      # otherwise the second pass of perform_with_both_string_paths_and_pathnames fails with
+      # Errno::EEXIST: File exists - a
+      FakeFS::FileSystem.clear
+    end
+  end
+
+  def test_special_chars_in_paths
+    perform_with_both_string_paths_and_pathnames do
+      path = string_or_pathname("{}.txt")
+      File.write(path, "a")
+      assert_equal File.exist?(path), true
+    end
+  end
 
   def test_creates_files_in_write_only_mode
     perform_with_both_string_paths_and_pathnames do

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -616,10 +616,9 @@ class FakeFSTest < Minitest::Test
       end
     end
   end
-require 'pry';
+
   def test_globs_in_exist
     perform_with_both_string_paths_and_pathnames do
-      # require 'pry'; binding.pry
       Dir.mkdir(string_or_pathname("a"))
       File.write(string_or_pathname("a/1.txt"), "a");
       assert_equal File.exist?("**/*.txt"), false


### PR DESCRIPTION
`FileSystem.find` was expanding globs causing subtle errors described in
* https://github.com/fakefs/fakefs/issues/264
* https://github.com/fakefs/fakefs/issues/423
files with special characters (`*` or `{}`) weren't found.

This PR addresses those problems. I've simplified `FileSystem.find` that it  doesn't expand globs now. In case glob expansion is needed (as in `Dir.glob`), we can use `FileSystem.find_with_glob` which contains the old implementation of `find` (the one with glob expantion).

Fixes https://github.com/fakefs/fakefs/issues/264
Fixes https://github.com/fakefs/fakefs/issues/423
