### PR TITLE
Fix binding.irb inside FakeFS

### DIFF
--- a/lib/fakefs/irb.rb
+++ b/lib/fakefs/irb.rb
@@ -1,0 +1,14 @@
+require 'irb'
+
+# Make the original file system classes available in IRB.
+::IRB::File = ::File
+::IRB::FileUtils = ::FileUtils
+::IRB::Dir = ::Dir
+::IRB::Pathname = ::Pathname
+
+# We need to setup IRB early, because the setup process itself requires locale files.
+# Otherwise we'll get an error from Budler
+#   Bundler::GemspecError: The gemspec for GEM_NAME was missing or broken.
+#     Try running `gem pristine GEM_NAME -v GEM_VERSION` to fix the cached spec.
+# because file sytem in bundler is stubbed.
+IRB.setup(binding.source_location[0], argv: [])

--- a/lib/fakefs/kernel.rb
+++ b/lib/fakefs/kernel.rb
@@ -32,8 +32,8 @@ module FakeFS
     end
 
     hijack :open do |*args, &block|
-      if args.first.start_with? '|'
-        # This is a system command
+      # This is a system command     or   we're inside IRB internals
+      if args.first.start_with?('|') || self.class.to_s.start_with?("IRB::")
         ::FakeFS::Kernel.captives[:original][:open].call(*args, &block)
       else
         name = args.shift

--- a/lib/fakefs/safe.rb
+++ b/lib/fakefs/safe.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'pathname'
 require 'fakefs/pry'
+require 'fakefs/irb'
 require 'fakefs/base'
 require 'fakefs/fake/file'
 require 'fakefs/fake/dir'

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2032,7 +2032,15 @@ class FakeFSTest < Minitest::Test
     :nread, :pwrite, :pread,
     :ready?,
     :wait, :wait_readable, :wait_writable, :wait_priority,
-    :timeout, :timeout=
+    :timeout, :timeout=,
+
+    # omit methods from io/console required by irb
+    :check_winsize_changed,
+    :clear_screen,
+    :console_mode, :console_mode=,
+    :cursor_down, :cursor_left, :cursor_right, :cursor_up,
+    :erase_line, :erase_screen,
+    :goto_column, :scroll_backward, :scroll_forward
   ].freeze
 
   OMITTED_JRUBY_FILE_METHODS = [

--- a/test/irb_test.rb
+++ b/test/irb_test.rb
@@ -1,0 +1,20 @@
+require_relative 'test_helper'
+
+require 'irb'
+
+class IrbTest < Minitest::Test
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def test_setup_irb
+    assert_nil IRB.setup(binding.source_location[0], argv: [])
+  end
+end


### PR DESCRIPTION
Changes:
* set filesystem constants to the real ones inside IRB (as we did to Pry
  in #485)
* tweak hijacking of Kernel#open, to use the original implementation
  inside IRB
* require `irb` and setup it once before initialising FakeFS to make
  load needed locales

With the last point - if I run `IRB.setup` for the first time inside FakeFS I got an error during locale loading:
```
Bundler::GemspecError: The gemspec for rake-13.0.6 at gems/ruby-3.0.4/specifications/rake-13.0.6.gemspec was missing or broken. Try running `gem pristine rake -v 13.0.6` to fix the cached spec.
   gems/ruby-3.0.4/gems/bundler-2.3.26/lib/bundler/stub_specification.rb:105:in `_remote_specification'
   gems/ruby-3.0.4/gems/bundler-2.3.26/lib/bundler/remote_specification.rb:113:in `method_missing'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems/specification.rb:1001:in `block in find_by_path'
   gems/ruby-3.0.4/gems/bundler-2.3.26/lib/bundler/spec_set.rb:155:in `each'
   gems/ruby-3.0.4/gems/bundler-2.3.26/lib/bundler/spec_set.rb:155:in `each'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems/specification.rb:999:in `find'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems/specification.rb:999:in `find_by_path'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/rubygems.rb:210:in `try_activate'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:159:in `block in search_file'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:167:in `block in each_localized_path'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:176:in `each_sublocale'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:166:in `each_localized_path'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:154:in `search_file'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:133:in `find'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:114:in `load'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/locale.rb:34:in `initialize'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/init.rb:144:in `new'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/init.rb:144:in `init_config'
   rubies/ruby-3.0.4/lib/ruby/3.0.0/irb/init.rb:17:in `setup'
   test/irb_test.rb:18:in `test_setup_irb'
```
that's why I decided to require `irb` and setup it during initialisation of FakeFS. If it's too much, we can intead advise in the documentation to add `require 'fakefs/irb'` manually if one wants to use IRB inside FakeFS.

Fixes #484