### PR TITLE
Ensure separation of positional/kwargs for Kernel.open (Fixes #490)

### DIFF
--- a/lib/fakefs/kernel.rb
+++ b/lib/fakefs/kernel.rb
@@ -18,8 +18,8 @@ module FakeFS
     def self.unhijack!
       captives[:original].each do |name, _prc|
         ::Kernel.send(:remove_method, name.to_sym)
-        ::Kernel.send(:define_method, name.to_sym, proc do |*args, &block|
-          ::FakeFS::Kernel.captives[:original][name].call(*args, &block)
+        ::Kernel.send(:define_method, name.to_sym, proc do |*args, **kwargs, &block|
+          ::FakeFS::Kernel.captives[:original][name].call(*args, **kwargs, &block)
         end)
         ::Kernel.send(:private, name.to_sym)
       end

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -51,4 +51,9 @@ class KernelTest < Minitest::Test
     out = open("|echo 'foo'")
     assert_equal "foo\n", out.gets
   end
+
+  def test_kernel_open_can_handle_kwargs_after_deactivation
+    FakeFS.deactivate!
+    open('/dev/null', autoclose: true)
+  end
 end


### PR DESCRIPTION
This was causing problems in Ruby 3 (tested on 3.2), when calling Kernel.open() with kwargs after deactivation.