### PR TITLE
fix: Add support for glob sort

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -127,7 +127,7 @@ module FakeFS
       end
     end
 
-    def self.glob(pattern, _flags = 0, flags: _flags, base: nil, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
+    def self.glob(pattern, _flags = 0, flags: _flags, base: nil, sort: true, &block) # rubocop:disable Lint/UnderscorePrefixedVariableName
       pwd = FileSystem.normalize_path(base || Dir.pwd)
       matches_for_pattern = lambda do |matcher|
         [FileSystem.find_with_glob(matcher, flags, true, dir: pwd) || []].flatten.map do |e|
@@ -138,8 +138,10 @@ module FakeFS
           else
             e.to_s.match(pwd_regex).post_match
           end
-        end.sort
+        end
       end
+
+      matches_for_pattern.sort! if sort
 
       files =
         if pattern.is_a?(Array)


### PR DESCRIPTION
## Summary

Add support for glob sort

## Description

Ruby 3.X added `sort` to the [method call for Dir.glob](https://docs.ruby-lang.org/en/3.0/Dir.html#method-c-glob). By default in Ruby 3 sorting is true. When using FakeFS and calling `Dir.glob(pattern, sort: false)` the calls will fail due to the missing `sort` parameter in the `self.glob` definition of FakeFS.

This change defaults `sort` to `true` so that existing usage of FakeFS will not change. The only change will be for users who pass `sort: false` to the glob method call.