### PR TITLE
Exclude '.' and '..' from Dir#children.

### DIFF
--- a/lib/fakefs/dir.rb
+++ b/lib/fakefs/dir.rb
@@ -40,7 +40,7 @@ module FakeFS
     end
 
     def children
-      each.to_a
+      each.reject { |entry_name| entry_name == '.' || entry_name == '..' }.to_a
     end
 
     def pos

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -3267,7 +3267,7 @@ class FakeFSTest < Minitest::Test
   end
 
   def test_directory_open_block
-    test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5']
+    test = ['file_1', 'file_2', 'file_3', 'file_4', 'file_5']
 
     FileUtils.mkdir_p('/this/path/should/be/here')
 
@@ -3278,7 +3278,7 @@ class FakeFSTest < Minitest::Test
     children = Dir.open('/this/path/should/be/here') do |dir|
       dir.children
     end
-
+      
     assert children.size == test.size
     test.each { |t| assert children.include?(t) }
   end


### PR DESCRIPTION
Fixes #515