### PR TITLE
fix: mkdir_p '/' insert nil-name entries into file system

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -56,6 +56,9 @@ module FakeFS
       end
 
       assert_dir d
+      # Short-circuit if added path is file system root, to avoid adding nil-name fs entries:
+      return fs if parts.empty?
+
       object.name = parts.last
       object.parent = d
       if object.is_a? FakeDir

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -3253,6 +3253,11 @@ class FakeFSTest < Minitest::Test
     end
   end
 
+  def test_mkdir_p_of_root_does_not_cause_faulty_entries
+    FileUtils.mkdir_p '/'
+    refute_includes FakeFS::FileSystem.fs.entries.map(&:name), nil
+  end
+
   def test_directory_open
     test = ['.', '..', 'file_1', 'file_2', 'file_3', 'file_4', 'file_5']
 


### PR DESCRIPTION
Fixes #521.