### PR TITLE
fix: readlink on non-existent target not raising ENOENT

### DIFF
--- a/lib/fakefs/file.rb
+++ b/lib/fakefs/file.rb
@@ -187,6 +187,7 @@ module FakeFS
 
     def self.readlink(path)
       symlink = FileSystem.find(path)
+      raise Errno::ENOENT unless symlink
       symlink.target
     end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -3392,6 +3392,12 @@ class FakeFSTest < Minitest::Test
     assert !File.exist?('/foo')
   end
 
+  def test_readlink_non_existent_raises_ENOENT
+    assert_raises(Errno::ENOENT) do
+      File.readlink('does_not_exist')
+    end
+  end
+
   def test_rename_renames_a_directories
     Dir.mkdir('/foo')
     File.write '/foo/file', 'content'


### PR DESCRIPTION
Fixes #523