### PR TITLE
Move irb to runtime dependency

### DIFF
--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -15,9 +15,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib README.md LICENSE`.split($/)
 
   spec.required_ruby_version = '>= 3.2.0' # sync with .github/workflows/test.yml and .rubocop.yml
+
+  spec.add_runtime_dependency 'irb', '< 2'
+
   spec.add_development_dependency 'bump'
   spec.add_development_dependency 'csv'
-  spec.add_development_dependency 'irb'
   spec.add_development_dependency 'maxitest'
   spec.add_development_dependency 'mutex_m'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
irb is a runtime dependency:

```
$ git grep "'irb'"
fakefs.gemspec:  spec.add_runtime_dependency 'irb', '< 2'
lib/fakefs/irb.rb:require 'irb'
test/irb_test.rb:require 'irb'
```

Since Ruby 4.0 it's not vendored within Ruby anymore.