### PR TITLE
Update CHANGELOG to show ruby version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## 3.0.2
 - fix: atime/mtime of copied entities in cp_r based on preserve option
+- Drop support for EOL Rubies (2.7/3.0/3.1)
 
 ## 3.0.1
 - fix dir children to not include . and ..


### PR DESCRIPTION
Adds note to version 3.0.2 that the required ruby version changed